### PR TITLE
Readonly, resolves DSD-DBS/capella-collab-manager#7

### DIFF
--- a/readonly/Dockerfile
+++ b/readonly/Dockerfile
@@ -1,0 +1,34 @@
+# Copyright 2021 DB Netz AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ARG BASE_IMAGE=capella/ease/remote
+FROM $BASE_IMAGE
+
+USER root
+RUN apt-get update && \
+    apt-get install -y git-lfs && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY prepare_workspace.py /opt/scripts/prepare_workspace.py
+RUN chown -R techuser /opt/capella
+ENV EASE_LOG_LOCATION=/proc/1/fd/1
+
+COPY startup.sh /home/techuser/.startup.sh
+RUN chmod +x /home/techuser/.startup.sh
+
+COPY git_askpass.py /etc/git_askpass.py
+ENV GIT_ASKPASS=/etc/git_askpass.py
+RUN chmod +x /etc/git_askpass.py
+
+USER techuser
+ENTRYPOINT [ "/home/techuser/.startup.sh" ]

--- a/readonly/git_askpass.py
+++ b/readonly/git_askpass.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+if __name__ == "__main__":
+    print(os.environ["GIT_" + sys.argv[1].split()[0].upper()])
+    raise SystemExit(0)

--- a/readonly/prepare_workspace.py
+++ b/readonly/prepare_workspace.py
@@ -1,0 +1,77 @@
+# onStartup: 0
+"""EASE script to prepare the workspace for read-only Containers.
+
+.. note:
+    The module expects that the scripts runs inside the EASE Docker Container.
+
+.. seealso:
+
+    The acronym EASE stands for "Eclipse Advanced Scripting Environment".
+    Further information: https://www.eclipse.org/ease/
+
+Environment variables
+======
+
+The following environment variables must be set:
+
+* ``GIT_USERNAME`` (if authentication is required)
+* ``GIT_PASSWORD`` (if authentication is required)
+* ``GIT_ENTRYPOINT`` (optional)
+
+"""
+# Standard library:
+import os
+import pathlib
+import typing as t
+
+# 1st party:
+import pyease.ease as ease
+import pyease.easeexceptions as exp
+
+BOT = ease.BOT
+
+logger = ease.logger
+ease.log_to_file(
+    log_file_path=os.environ.get(
+        "EASE_LOG_LOCATION", ease.workspace_path() / "prepare_workspace.log"
+    )
+)
+
+
+def import_git_project_from_folder():
+    """Import cloned Git project from folder into Capella workspace."""
+    entrypoint = os.environ.get("GIT_ENTRYPOINT", "")
+    base_path = pathlib.Path("/home/techuser/model")
+    if entrypoint:
+        path = (base_path / entrypoint).parent
+    else:
+        path = base_path
+    logger.info(f"Import Git project from folder ('{path}')...")
+    BOT.menu("File").menu("Import...").click()
+    git_node: t.Any = BOT.tree().getTreeItem("General")
+    git_node.select()
+    git_node.expand()
+    git_node.getNode("Projects from Folder or Archive").doubleClick()
+    combo_box: t.Any = BOT.comboBox(0)
+    combo_box.setText(str(path))
+    ease.click_button_with_label(label="Finish", timeout=60000, interval=500)
+    BOT.waitUntil(ease.MenuIsAvailable("File"), 600000, 500)
+
+
+if __name__ == "__main__":
+    ease.log_intro_messages()
+    if BOT is None:
+        raise exp.EaseNoSWTWorkbenchBotError
+
+    try:
+        ease.open_eclipse_perspective("Capella")
+        import_git_project_from_folder()
+        ease.close_eclipse_view("Console")
+        exit_signal = 30
+    except Exception:
+        logger.exception("An unexpected error occured:")
+        exit_signal = 9
+
+    logger.info("Exit Capella.")
+    ease.kill_capella_process(exit_signal)
+    logger.info("Done.")

--- a/readonly/startup.sh
+++ b/readonly/startup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+echo -e "tmp_passwd\n$RMT_PASSWORD\n$RMT_PASSWORD" | passwd
+
+# Load git model
+git clone $GIT_URL /home/techuser/model
+git checkout $GIT_REVISION
+
+# Prepare Workspace
+echo "Preparing workspace..."
+export DISPLAY=:99;
+Xvfb :99 -screen 0 1920x1080x8 -nolisten tcp &
+/opt/capella/capella -data /workspace > /dev/null || r=$?;
+if [[ -n "$r" ]] && [[ "$r" == 158 || "$r" == 0 ]]
+then 
+    echo "Workspace preparation done.";
+else 
+    echo "Workspace preparation failed! Please check the EASE logs.";
+    exit 1;
+fi
+
+# Ensure that Capella is closed.
+pkill java
+pkill capella
+
+unset GIT_USERNAME;
+unset GIT_PASSWORD;
+rm /opt/scripts/*;
+
+exec supervisord


### PR DESCRIPTION
This adds support for readonly Dockerimages / -containers. 

Readonly containers will pull the model from a git repository, loads the model into the workspace via EASE and spawns up a RDP session. 