### PR TITLE
Fix license injection

### DIFF
--- a/capella/Dockerfile
+++ b/capella/Dockerfile
@@ -58,7 +58,8 @@ RUN if [ -s capella.zip ]; then \
 # Set Permissions
 RUN chmod +x capella/capella && \
     chmod -R +x capella/jre/bin && \
-    chmod -R +x capella/jre/lib
+    chmod -R +x capella/jre/lib && \
+    chown -R techuser /opt/capella
 
 # Install Dropins for Capella
 COPY ./dropins /opt/capella/dropins

--- a/remote/startup.sh
+++ b/remote/startup.sh
@@ -14,6 +14,6 @@ fi
 python3 /opt/setup_workspace.py;
 
 # Replace environment variables in capella.ini, e.g. licences
-envsubst < /opt/capella/capella.ini | tee /opt/capella/capella.ini;
+envsubst < /opt/capella/capella.ini > /tmp/capella.ini && mv /tmp/capella.ini /opt/capella/capella.ini;
 
 exec supervisord


### PR DESCRIPTION
This fixes a indeterministic behaviour.
tee did trucate the file sometimes before it was substituted, which resulted in an empty file.
Resolves #14