### PR TITLE
Add zip to the base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
     apt-get install --yes \
     python3 \
     python3-pip \
+    zip \
     unzip && rm -rf /var/lib/apt/lists/*
 
 # Create techuser with UID


### PR DESCRIPTION
Zip is used by the download feature of capella-collab-manager (https://github.com/DSD-DBS/capella-collab-manager/pull/201) to package files before download. Unfortunately tar was not sufficient: that file format is not understood by Windows.