### PR TITLE
fix: use techuser for ease installation

### DIFF
--- a/ease/Dockerfile
+++ b/ease/Dockerfile
@@ -40,6 +40,8 @@ ONBUILD ENV SWTBOT_REPOSITORY=https://download.eclipse.org/technology/swtbot/rel
 
 FROM build_${BUILD_TYPE}
 
+USER techuser
+
 # Install EASE Dependencies
 # - org.py4j.feature.feature.group
 RUN /opt/capella/capella \
@@ -88,6 +90,8 @@ RUN pip install /tmp/pyease
 ENV EASE_WORKSPACE /workspace
 ENV EASE_SCRIPTS_LOCATION /opt/scripts
 ENV EASE_LOG_LOCATION=/proc/1/fd/1
+
+USER root
 
 RUN mkdir /opt/scripts && \
     chown techuser /opt/scripts


### PR DESCRIPTION
This PR fixes an error in the `capella/ease/remote` image which prevented Capella to start. Permissions for the installed EASE extensions were set to root. 