### PR TITLE
t4c/client/remote repositories across multiple instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ node_exporter*
 prometheus*
 .venv
 .vscode
+.idea

--- a/Makefile
+++ b/Makefile
@@ -142,13 +142,27 @@ run-capella/readonly-debug: capella/readonly
 		--entrypoint bash \
 		$(DOCKER_PREFIX)capella/readonly
 
-run-t4c/client/remote: t4c/client/remote
+run-t4c/client/remote/repositories: t4c/client/remote
 	docker rm /t4c-client-remote || true
 	docker run -d \
 		-e T4C_LICENCE_SECRET=$(T4C_LICENCE_SECRET) \
 		-e T4C_SERVER_HOST=$(T4C_SERVER_HOST) \
 		-e T4C_SERVER_PORT=$(T4C_SERVER_PORT) \
 		-e T4C_REPOSITORIES=$(T4C_REPOSITORIES) \
+		-e RMT_PASSWORD=$(RMT_PASSWORD) \
+		-e FILESERVICE_PASSWORD=$(RMT_PASSWORD) \
+		-e T4C_USERNAME=$(T4C_USERNAME) \
+		-p $(RDP_PORT):3389 \
+		-p $(FILESYSTEM_PORT):8000 \
+		-p $(METRICS_PORT):9118 \
+		--name t4c-client-remote \
+		$(DOCKER_PREFIX)t4c/client/remote
+
+run-t4c/client/remote/json: t4c/client/remote
+	docker rm /t4c-client-remote || true
+	docker run -d \
+		-e T4C_LICENCE_SECRET=$(T4C_LICENCE_SECRET) \
+		-e T4C_JSON=$(T4C_JSON) \
 		-e RMT_PASSWORD=$(RMT_PASSWORD) \
 		-e FILESERVICE_PASSWORD=$(RMT_PASSWORD) \
 		-e T4C_USERNAME=$(T4C_USERNAME) \

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ run-capella/readonly-debug: capella/readonly
 		--entrypoint bash \
 		$(DOCKER_PREFIX)capella/readonly
 
-run-t4c/client/remote/repositories: t4c/client/remote
+run-t4c/client/remote-legacy: t4c/client/remote
 	docker rm /t4c-client-remote || true
 	docker run -d \
 		-e T4C_LICENCE_SECRET=$(T4C_LICENCE_SECRET) \
@@ -155,10 +155,10 @@ run-t4c/client/remote/repositories: t4c/client/remote
 		-p $(RDP_PORT):3389 \
 		-p $(FILESYSTEM_PORT):8000 \
 		-p $(METRICS_PORT):9118 \
-		--name t4c-client-remote \
+		--name t4c-client-remote-legacy \
 		$(DOCKER_PREFIX)t4c/client/remote
 
-run-t4c/client/remote/json: t4c/client/remote
+run-t4c/client/remote-json: t4c/client/remote
 	docker rm /t4c-client-remote || true
 	docker run -d \
 		-e T4C_LICENCE_SECRET=$(T4C_LICENCE_SECRET) \
@@ -169,7 +169,7 @@ run-t4c/client/remote/json: t4c/client/remote
 		-p $(RDP_PORT):3389 \
 		-p $(FILESYSTEM_PORT):8000 \
 		-p $(METRICS_PORT):9118 \
-		--name t4c-client-remote \
+		--name t4c-client-remote-json \
 		$(DOCKER_PREFIX)t4c/client/remote
 
 run-t4c/client/importer: t4c/client/importer

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Capella should then start automatically.
 docker run -d \
     -p $RDP_EXTERNAL_PORT:3389 \
     -e T4C_LICENCE_SECRET=XXX \
-    -e T4C_JSON='[{"instance": "", "port": 0, "host": "", "instance": ""}]' \
+    -e T4C_JSON='[{"repository": "", "port": 0, "host": "", "instance": ""}]' \
     -e T4C_SERVER_HOST=$T4C_SERVER_HOST \
     -e T4C_SERVER_PORT=$T4C_SERVER_PORT \
     -e T4C_REPOSITORIES=$T4C_REPOSITORIES \

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ Please replace the followings variables:
 - `$T4C_LICENCE_SECRET` to your TeamForCapella licence secret.
 - `$T4C_USERNAME` is the username that is suggested when connecting to t4c.
 - `$FILESERVICE_PASSWORD` with the password for the fileservice, which is used as basic authentication password.
-- `AUTOSTART_CAPELLA` defines the autostart behaviour of Capella. When set to 1 (default), Capella will be started as soon
+- `AUTOSTART_CAPELLA` defines the auto-start behaviour of Capella. When set to 1 (default), Capella will be started as soon
   as an RDP connection has been established to the running container.
 - `RESTART_CAPELLA` defines the restart behaviour of Capella. When set to 1 (default) and when `AUTOSTART_CAPELLA=1`,
   Capella will be re-started as soon as it has been exited (after clean quits as

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Please replace the followings variables:
     "repository": "repoCapella",
     "host": "localhost",
     "port": 2036,
-    "instance": "" //optional, in case of duplicate name
+    "instance": "" //optional, required if the repository names are not unique
   }]  
   ```
   (`$T4C_SERVER_HOST`, `$T4C_SERVER_PORT` and `$T4C_REPOSITORIES` will be ignored.)

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ Please replace the followings variables:
   [{
     "repository": "repoCapella",
     "host": "localhost",
-    "port": 1337,
+    "port": 2036,
     "instance": "" //optional, in case of duplicate name
   }]  
   ```

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Capella should then start automatically.
 docker run -d \
     -p $RDP_EXTERNAL_PORT:3389 \
     -e T4C_LICENCE_SECRET=XXX \
-    -e T4C_JSON='[{"repository": "", "port": 0, "host": "", "instance": ""}]' \
+    -e T4C_JSON='[{"repository": "", "port": 0, "host": "", "instance": "", "protocol": "ssl"}]' \
     -e T4C_SERVER_HOST=$T4C_SERVER_HOST \
     -e T4C_SERVER_PORT=$T4C_SERVER_PORT \
     -e T4C_REPOSITORIES=$T4C_REPOSITORIES \
@@ -405,7 +405,8 @@ Please replace the followings variables:
     "repository": "repoCapella",
     "host": "localhost",
     "port": 2036,
-    "instance": "" //optional, required if the repository names are not unique
+    "instance": "", //optional, required if the repository names are not unique
+    "protocol": "ssl", //optional, defaults to ssl
   }]
   ```
 

--- a/README.md
+++ b/README.md
@@ -406,8 +406,9 @@ Please replace the followings variables:
     "host": "localhost",
     "port": 2036,
     "instance": "" //optional, required if the repository names are not unique
-  }]  
+  }]
   ```
+
   (`$T4C_SERVER_HOST`, `$T4C_SERVER_PORT` and `$T4C_REPOSITORIES` will be ignored.)
 - Or (if `$T4C_JSON` is not defined)
   - `$T4C_SERVER_HOST` to the IP-Address of your T4C server (default: `127.0.0.1`).

--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Capella should then start automatically.
 docker run -d \
     -p $RDP_EXTERNAL_PORT:3389 \
     -e T4C_LICENCE_SECRET=XXX \
+    -e T4C_JSON='[{"instance": "", "port": 0, "host": "", "instance": ""}]' \
     -e T4C_SERVER_HOST=$T4C_SERVER_HOST \
     -e T4C_SERVER_PORT=$T4C_SERVER_PORT \
     -e T4C_REPOSITORIES=$T4C_REPOSITORIES \
@@ -390,10 +391,6 @@ Please replace the followings variables:
 - `$RDP_EXTERNAL_PORT` to the external port for RDP on your host (usually `3389`)
 - `$RMT_PASSWORD` is the password for remote connections (for the login via RDP).
 - `$T4C_LICENCE_SECRET` to your TeamForCapella licence secret.
-- `$T4C_SERVER_HOST` to the IP-Address of your T4C server (default: `127.0.0.1`).
-- `$T4C_SERVER_PORT` to the port of your T4C server (default: `2036`).
-- `$T4C_REPOSITORIES` is a comma-seperated list of repositories. These repositories show
-  up as default options on connection (e.g. `repo1,repo2`).
 - `$T4C_USERNAME` is the username that is suggested when connecting to t4c.
 - `$FILESERVICE_PASSWORD` with the password for the fileservice, which is used as basic authentication password.
 - `AUTOSTART_CAPELLA` defines the autostart behaviour of Capella. When set to 1 (default), Capella will be started as soon
@@ -401,6 +398,23 @@ Please replace the followings variables:
 - `RESTART_CAPELLA` defines the restart behaviour of Capella. When set to 1 (default) and when `AUTOSTART_CAPELLA=1`,
   Capella will be re-started as soon as it has been exited (after clean quits as
   well as crashs).
+- Either `$T4C_JSON` a list of repositories with name, host, port and instance name as a JSON:
+
+  ```json
+  [{
+    "repository":  "",
+    "host":  "",
+    "port": 1337,
+    "instance": "" //optional, in case of duplicate name
+  }]  
+  ```
+  (`$T4C_SERVER_HOST`, `$T4C_SERVER_PORT` and `$T4C_REPOSITORIES` will be ignored.)
+- Or (if `$T4C_JSON` is not defined)
+  - `$T4C_SERVER_HOST` to the IP-Address of your T4C server (default: `127.0.0.1`).
+  - `$T4C_SERVER_PORT` to the port of your T4C server (default: `2036`).
+  - `$T4C_REPOSITORIES` is a comma-seperated list of repositories. These repositories show
+    up as default options on connection (e.g. `repo1,repo2`).
+
 
 After starting the container, you should be able to connect to
 `localhost:$RDP_EXTERNAL_PORT` with your preferred RDP Client.

--- a/README.md
+++ b/README.md
@@ -402,8 +402,8 @@ Please replace the followings variables:
 
   ```json
   [{
-    "repository":  "",
-    "host":  "",
+    "repository": "repoCapella",
+    "host": "localhost",
     "port": 1337,
     "instance": "" //optional, in case of duplicate name
   }]  

--- a/remote/metrics.py
+++ b/remote/metrics.py
@@ -9,8 +9,7 @@ import subprocess
 from datetime import datetime, timedelta
 from wsgiref.simple_server import make_server
 
-from prometheus_client import Gauge, make_wsgi_app, REGISTRY
-
+from prometheus_client import REGISTRY, Gauge, make_wsgi_app
 
 METRICS_PORT = int(
     os.getenv("METRICS_PORT", 9118)  # pylint: disable=invalid-envvar-default

--- a/remote/setup_workspace.py
+++ b/remote/setup_workspace.py
@@ -39,6 +39,16 @@ def replace_config(path: pathlib.Path, key: str, value: str) -> None:
     path.write_text(file_content)
 
 
+def replace_config_repositories(key: str, value: str) -> None:
+    replace_config(
+        REPOSITORIES_BASE_PATH
+        / "fr.obeo.dsl.viewpoint.collab"
+        / "repository.properties",
+        key,
+        value,
+    )
+
+
 def setup_repositories() -> None:
     t4c_repositories = os.getenv("T4C_REPOSITORIES", "").split(",")
     t4c_host = os.getenv("T4C_SERVER_HOST", "localhost")
@@ -55,10 +65,7 @@ def setup_repositories() -> None:
             if count > 1
         ]
         for repo in t4c_repos:
-            replace_config(
-                REPOSITORIES_BASE_PATH
-                / "fr.obeo.dsl.viewpoint.collab"
-                / "repository.properties",
+            replace_config_repositories(
                 f"{repo['repository']}\\ ({repo['instance']})"
                 if repo["repository"] in duplicate_names
                 else repo["repository"],
@@ -67,10 +74,7 @@ def setup_repositories() -> None:
 
     else:
         for repo in t4c_repositories:
-            replace_config(
-                REPOSITORIES_BASE_PATH
-                / "fr.obeo.dsl.viewpoint.collab"
-                / "repository.properties",
+            replace_config_repositories(
                 repo,
                 rf"tcp\://{t4c_host}\:{t4c_port}/{repo}",
             )

--- a/remote/setup_workspace.py
+++ b/remote/setup_workspace.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
+from collections import Counter
+import json
 import logging
 import os
 import pathlib
@@ -41,15 +43,29 @@ def setup_repositories() -> None:
     t4c_repositories = os.getenv("T4C_REPOSITORIES", "").split(",")
     t4c_host = os.getenv("T4C_SERVER_HOST", "localhost")
     t4c_port = os.getenv("T4C_SERVER_PORT", 2036)
+    t4c_json = os.getenv("T4C_JSON", None)
 
-    for repo in t4c_repositories:
-        replace_config(
-            REPOSITORIES_BASE_PATH
-            / "fr.obeo.dsl.viewpoint.collab"
-            / "repository.properties",
-            repo,
-            rf"tcp\://{t4c_host}\:{t4c_port}/{repo}",
-        )
+    if t4c_json:
+        t4c_repos: list[dict[str, str]] = json.loads(t4c_json)
+        duplicate_names = [name for name, count in Counter([repo['repository'] for repo in t4c_repos]).items() if count > 1]
+        for repo in t4c_repos:
+            replace_config(
+                REPOSITORIES_BASE_PATH
+                / "fr.obeo.dsl.viewpoint.collab"
+                / "repository.properties",
+                f"{repo['repository']}\\ ({repo['instance']})" if repo['repository'] in duplicate_names else repo['repository'],
+                rf"tcp\://{repo['host']}\:{repo['port']}/{repo['repository']}"
+            )
+
+    else:
+        for repo in t4c_repositories:
+            replace_config(
+                REPOSITORIES_BASE_PATH
+                / "fr.obeo.dsl.viewpoint.collab"
+                / "repository.properties",
+                repo,
+                rf"tcp\://{t4c_host}\:{t4c_port}/{repo}",
+            )
 
 
 if __name__ == "__main__":

--- a/remote/setup_workspace.py
+++ b/remote/setup_workspace.py
@@ -39,13 +39,15 @@ def replace_config(path: pathlib.Path, key: str, value: str) -> None:
     path.write_text(file_content)
 
 
-def replace_config_repositories(key: str, value: str) -> None:
+def replace_config_repositories(
+    key: str, host: str, port: str | int, repository: str
+) -> None:
     replace_config(
         REPOSITORIES_BASE_PATH
         / "fr.obeo.dsl.viewpoint.collab"
         / "repository.properties",
         key,
-        value,
+        rf"tcp\://{host}\:{port}/{repository}",
     )
 
 
@@ -69,15 +71,14 @@ def setup_repositories() -> None:
                 f"{repo['repository']}\\ ({repo['instance']})"
                 if repo["repository"] in duplicate_names
                 else repo["repository"],
-                rf"tcp\://{repo['host']}\:{repo['port']}/{repo['repository']}",
+                repo["host"],
+                repo["port"],
+                repo["repository"],
             )
 
     else:
         for repo in t4c_repositories:
-            replace_config_repositories(
-                repo,
-                rf"tcp\://{t4c_host}\:{t4c_port}/{repo}",
-            )
+            replace_config_repositories(repo, t4c_host, t4c_port, repo)
 
 
 if __name__ == "__main__":

--- a/remote/setup_workspace.py
+++ b/remote/setup_workspace.py
@@ -1,12 +1,12 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from collections import Counter
 import json
 import logging
 import os
 import pathlib
 import re
+from collections import Counter
 
 logging.basicConfig(level=logging.DEBUG)
 LOGGER = logging.getLogger("prepare_workspace")
@@ -47,14 +47,22 @@ def setup_repositories() -> None:
 
     if t4c_json:
         t4c_repos: list[dict[str, str]] = json.loads(t4c_json)
-        duplicate_names = [name for name, count in Counter([repo['repository'] for repo in t4c_repos]).items() if count > 1]
+        duplicate_names = [
+            name
+            for name, count in Counter(
+                [repo["repository"] for repo in t4c_repos]
+            ).items()
+            if count > 1
+        ]
         for repo in t4c_repos:
             replace_config(
                 REPOSITORIES_BASE_PATH
                 / "fr.obeo.dsl.viewpoint.collab"
                 / "repository.properties",
-                f"{repo['repository']}\\ ({repo['instance']})" if repo['repository'] in duplicate_names else repo['repository'],
-                rf"tcp\://{repo['host']}\:{repo['port']}/{repo['repository']}"
+                f"{repo['repository']}\\ ({repo['instance']})"
+                if repo["repository"] in duplicate_names
+                else repo["repository"],
+                rf"tcp\://{repo['host']}\:{repo['port']}/{repo['repository']}",
             )
 
     else:

--- a/remote/setup_workspace.py
+++ b/remote/setup_workspace.py
@@ -78,7 +78,7 @@ def setup_repositories() -> None:
                 else repo["repository"],
                 protocol or "tcp",
                 repo["host"],
-                repo["port"] or 2036,
+                repo["port"],
                 repo["repository"],
             )
 

--- a/remote/setup_workspace.py
+++ b/remote/setup_workspace.py
@@ -39,7 +39,7 @@ def replace_config(path: pathlib.Path, key: str, value: str) -> None:
     path.write_text(file_content)
 
 
-def replace_config_repositories(
+def inject_t4c_connection_details(
     key: str, host: str, port: str | int, repository: str
 ) -> None:
     replace_config(
@@ -67,7 +67,7 @@ def setup_repositories() -> None:
             if count > 1
         ]
         for repo in t4c_repos:
-            replace_config_repositories(
+            inject_t4c_connection_details(
                 f"{repo['repository']}\\ ({repo['instance']})"
                 if repo["repository"] in duplicate_names
                 else repo["repository"],
@@ -78,7 +78,7 @@ def setup_repositories() -> None:
 
     else:
         for repo in t4c_repositories:
-            replace_config_repositories(repo, t4c_host, t4c_port, repo)
+            inject_t4c_connection_details(repo, t4c_host, t4c_port, repo)
 
 
 if __name__ == "__main__":

--- a/remote/setup_workspace.py
+++ b/remote/setup_workspace.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import json
 import logging
 import os

--- a/remote/setup_workspace.py
+++ b/remote/setup_workspace.py
@@ -42,14 +42,14 @@ def replace_config(path: pathlib.Path, key: str, value: str) -> None:
 
 
 def inject_t4c_connection_details(
-    key: str, host: str, port: str | int, repository: str
+    key: str, protocol: str, host: str, port: str | int, repository: str
 ) -> None:
     replace_config(
         REPOSITORIES_BASE_PATH
         / "fr.obeo.dsl.viewpoint.collab"
         / "repository.properties",
         key,
-        rf"tcp\://{host}\:{port}/{repository}",
+        rf"{protocol}\://{host}\:{port}/{repository}",
     )
 
 
@@ -69,12 +69,16 @@ def setup_repositories() -> None:
             if count > 1
         ]
         for repo in t4c_repos:
+            protocol = repo["protocol"] if "protocol" in repo else None
+            if protocol:
+                assert protocol in ["tcp", "ssl", "ws", "wss"]
             inject_t4c_connection_details(
                 f"{repo['repository']}\\ ({repo['instance']})"
                 if repo["repository"] in duplicate_names
                 else repo["repository"],
+                protocol or "tcp",
                 repo["host"],
-                repo["port"],
+                repo["port"] or 2036,
                 repo["repository"],
             )
 

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import logging
 import pathlib

--- a/tests/test_repositories_seeding.py
+++ b/tests/test_repositories_seeding.py
@@ -129,7 +129,7 @@ def get_container(
 def wait_for_container(container: docker.models.containers.Container) -> None:
     log_line = 0
     for _ in range(int(timeout / 2)):
-        log.info("Wait until ---START_SESSION---")
+        log.info("Wait until INFO success: xrdp-sesman entered RUNNING state")
 
         splitted_logs = container.logs().decode().splitlines()
         log.debug("Current log: %s", "\n".join(splitted_logs[log_line:]))

--- a/tests/test_repositories_seeding.py
+++ b/tests/test_repositories_seeding.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import logging
+import pathlib
+import re
+import time
+
+import docker.models.containers
+import pytest
+
+log = logging.getLogger(__file__)
+log.setLevel("DEBUG")
+client = docker.from_env()
+from collections.abc import Generator
+
+timeout = 120  # Timeout in seconds
+default_env = {
+    "T4C_LICENCE_SECRET": "",
+    "RMT_PASSWORD": "my_long_password",
+    "FILESERVICE_PASSWORD": "password",
+    "T4C_USERNAME": "techuser",
+}
+
+
+@pytest.fixture(name="mode", params=["json", "repositories"])
+def fixture_mode(request) -> str:
+    return request.param
+
+
+@pytest.fixture(
+    name="container_success",
+)
+def fixture_container_success(
+    mode: str,
+    tmp_path: pathlib.Path,
+) -> Generator[docker.models.containers.Container]:
+    env = {
+        "json": {
+            **default_env,
+            "T4C_JSON": json.dumps(
+                [
+                    {
+                        "repository": "name",
+                        "port": 2036,
+                        "host": "instance-host",
+                        "instance": "dev-5.0",
+                    },
+                    {
+                        "repository": "name",
+                        "port": 2036,
+                        "host": "instance-host",
+                        "instance": "dev-5.2",
+                    },
+                    {"repository": "test", "port": 2036, "host": "instance-host"},
+                ]
+            ),
+        },
+        "repositories": {
+            **default_env,
+            "T4C_SERVER_HOST": "instance-host",
+            "T4C_SERVER_PORT": "2036",
+            "T4C_REPOSITORIES": "repo1,repo2",
+        },
+    }[mode]
+    yield get_container(environment=env, tmp_path=tmp_path)
+
+
+@pytest.fixture(name="container_failure")
+def fixture_container_failure(
+    mode: str,
+) -> Generator[docker.models.containers.Container]:
+    env = {
+        "json": {
+            **default_env,
+            "T4C_JSON": json.dumps(
+                [
+                    {
+                        "repository": "duplicate-name",
+                        "port": 2036,
+                        "host": "instance-host",
+                    },
+                    {
+                        "repository": "duplicate-name",
+                        "port": 2036,
+                        "host": "instance-host",
+                    },
+                    {"repository": "test", "port": 2036, "host": "instance-host"},
+                ]
+            ),
+        },
+        "repositories": {
+            **default_env,
+            "T4C_SERVER_HOST": "instance-host",
+            "T4C_SERVER_PORT": "2036",
+        },
+    }[mode]
+    yield get_container(environment=env)
+
+
+def get_container(
+    environment: dict[str, str], tmp_path: pathlib.Path = None
+) -> Generator[docker.models.containers.Container]:
+    log.info(tmp_path)
+    volumes = (
+        {
+            str(tmp_path): {
+                "bind": "/opt/capella/configuration",
+                "model": "rw",
+            }
+        }
+        if tmp_path
+        else {}
+    )
+    try:
+        container = client.containers.run(
+            image="t4c/client/remote",
+            detach=True,
+            environment=environment | {"RMT_PASSWORD": "password"},
+            volumes=volumes,
+        )
+        yield container
+    finally:
+        container.stop()
+        container.remove()
+
+
+def wait_for_container(container: docker.models.containers.Container) -> None:
+    log_line = 0
+    for _ in range(int(timeout / 2)):
+        log.info("Wait until ---START_SESSION---")
+
+        splitted_logs = container.logs().decode().splitlines()
+        log.debug("Current log: %s", "\n".join(splitted_logs[log_line:]))
+        log_line = len(splitted_logs)
+
+        if b"INFO success: xrdp-sesman entered RUNNING state" in container.logs():
+            log.info("Loading of model finished")
+            break
+        container.reload()
+        if container.status == "exited":
+            log.error("Log from container: %s", container.logs().decode())
+            raise RuntimeError("Container exited unexpectedly")
+
+        time.sleep(2)
+
+    else:
+        log.error("Log from container: %s", container.logs().decode())
+        raise TimeoutError("Timeout while waiting for model loading")
+
+
+def test_repositories_seeding(
+    container_success: Generator[docker.models.containers.Container],
+    mode: str,
+    tmp_path: pathlib.Path,
+):
+    tmp_path.chmod(0o777)
+
+    container = next(container_success)
+    wait_for_container(container)
+
+    path = tmp_path / "fr.obeo.dsl.viewpoint.collab" / "repository.properties"
+    assert path.exists()
+    file_content = path.read_text()
+
+    if mode == "json":
+        repositories = {
+            r"name\\ \(dev-5.0\)": r"tcp\://instance-host\:2036/name",
+            r"name\\ \(dev-5.2\)": r"tcp\://instance-host\:2036/name",
+            r"test": r"tcp\://instance-host\:2036/test",
+        }
+    elif mode == "repositories":
+        repositories = {
+            r"repo1": r"tcp\://instance-host\:2036/repo1",
+            r"repo2": r"tcp\://instance-host\:2036/repo2",
+        }
+    else:
+        repositories = {}
+    for key in repositories:
+        assert repositories[key] == re.search(f"{key}=(.+)", file_content).group(1)
+
+
+def test_invalid_env_variable(
+    container_failure: Generator[docker.models.containers.Container],
+):
+    container = next(container_failure)
+    with pytest.raises(RuntimeError):
+        wait_for_container(container)


### PR DESCRIPTION
Adds the support of repositories across multiple instances on `t4c/client/remote` docker image, with the environment variable `T4C_JSON`.
See updated doc for more information.