### PR TITLE
Build images in CI

### DIFF
--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   registry: ghcr.io/dsd-dbs/capella-dockerimages/
-  images: capella/remote capella/readonly capella/ease
+  images: capella/remote capella/readonly capella/ease capella/cli
 
 jobs:
   deploy-docker-images:

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -7,19 +7,12 @@ on:
 
 env:
   registry: ghcr.io/dsd-dbs/capella-dockerimages/
+  images: capella/remote capella/readonly capella/ease
 
 jobs:
   deploy-docker-images:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      max-parallel: 1
-      matrix:
-        image:
-          - capella/remote
-          - capella/readonly
-          - capella/ease
-    name: build and push ${{ matrix.image }}
+    name: build and push
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -37,11 +30,13 @@ jobs:
         id: sha
         run: echo "short=$(git rev-parse --short HEAD)" > "$GITHUB_OUTPUT"
       - name: Build
-        run: make ${{ matrix.image }} DOCKER_PREFIX=${{ env.registry }} DOCKER_TAG=${{ steps.sha.outputs.short }}
+        run: make ${{ env.images }} DOCKER_PREFIX=${{ env.registry }} DOCKER_TAG=${{ steps.sha.outputs.short }}
       - name: Test readonly image
-        if: matrix.image == 'capella/readonly'
         run: |
           pip install pytest docker
           pytest tests
       - name: Push
-        run: docker push ${{ env.registry }}${{ matrix.image }}:${{ steps.sha.outputs.short }}
+        run: |
+          for image in ${{ env.images }}
+          do docker push ${{ env.registry }}$image:${{ steps.sha.outputs.short }}
+          done

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -38,7 +38,8 @@ jobs:
         run: echo "short=$(git rev-parse --short HEAD)" > "$GITHUB_OUTPUT"
       - name: Build
         run: make ${{ matrix.image }} DOCKER_PREFIX=${{ env.registry }} DOCKER_TAG=${{ steps.sha.outputs.short }}
-      - name: Test
+      - name: Test readonly image
+        if: matrix.image == 'capella/readonly'
         run: |
           pip install pytest docker
           pytest tests

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Set outputs
         id: tag
         run: |
-          echo "branch=$(git rev-parse --abbrev-ref HEAD)" > "$GITHUB_OUTPUT"
-          echo "sha=$(git rev-parse --short HEAD)" > "$GITHUB_OUTPUT"
+          echo "branch=$(git rev-parse --abbrev-ref HEAD)" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: Build
         run: >
           make ${{ env.images }}

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -31,7 +31,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set outputs
         id: sha
-        run: echo "short=$(git rev-parse --short HEAD)" > $GITHUB_OUTPUTS
+        run: echo "short=$(git rev-parse --short HEAD)" > "$GITHUB_OUTPUT"
       - name: Build
         run: make ${{ matrix.image }} DOCKER_PREFIX=${{ env.registry }} DOCKER_TAG=${{ steps.sha.outputs.short }}
       # - name: Build and push Docker image

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -27,16 +27,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set outputs
-        id: sha
-        run: echo "short=$(git rev-parse --short HEAD)" > "$GITHUB_OUTPUT"
+        id: tag
+        run: echo "branch=$(git rev-parse --abbrev-ref HEAD)" > "$GITHUB_OUTPUT"
       - name: Build
-        run: make ${{ env.images }} DOCKER_PREFIX=${{ env.registry }} DOCKER_TAG=${{ steps.sha.outputs.short }}
+        run: make ${{ env.images }} DOCKER_PREFIX=${{ env.registry }} DOCKER_TAG=${{ steps.tag.outputs.branch }}
       - name: Test readonly image
         run: |
           pip install pytest docker
-          DOCKER_CAPELLA_READONLY="${{ env.registry }}capella/readonly:${{ steps.sha.outputs.short }}" pytest tests
+          DOCKER_CAPELLA_READONLY="${{ env.registry }}capella/readonly:${{ steps.tag.outputs.branch }}" pytest tests
       - name: Push
         run: |
           for image in ${{ env.images }}
-          do docker push ${{ env.registry }}$image:${{ steps.sha.outputs.short }}
+          do docker push ${{ env.registry }}$image:${{ steps.tag.outputs.branch }}
           done

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v4.3.0
+        with:
+          python-version: 3.10
       - name: Login to github container registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -34,9 +34,16 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set outputs
         id: tag
-        run: echo "branch=$(git rev-parse --abbrev-ref HEAD)" > "$GITHUB_OUTPUT"
+        run: |
+          echo "branch=$(git rev-parse --abbrev-ref HEAD)" > "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse --short HEAD)" > "$GITHUB_OUTPUT"
       - name: Build
-        run: make ${{ env.images }} CAPELLA_VERSION=${{ matrix.capella_version }} DOCKER_PREFIX=${{ env.registry }} CAPELLA_DOCKERIMAGES_REVISION=${{ steps.tag.outputs.branch }}
+        run: >
+          make ${{ env.images }}
+          CAPELLA_VERSION=${{ matrix.capella_version }}
+          DOCKER_PREFIX=${{ env.registry }}
+          CAPELLA_DOCKERIMAGES_REVISION=${{ steps.tag.outputs.branch }}
+          DOCKER_BUILD_FLAGS="--label git-short-sha=${{ steps.tag.outputs.sha }}"
       - name: Test readonly image
         run: |
           pip install pytest docker

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Test readonly image
         run: |
           pip install pytest docker
-          DOCKER_CAPELLA_READONLY="${{ env.registry }}capella/readonly:${{ matrix.capella_version }}-${{ steps.tag.outputs.branch }}" pytest tests
+          DOCKER_CAPELLA_READONLY="${{ env.registry }}capella/readonly:${{ matrix.capella_version }}-${{ steps.tag.outputs.branch }}" pytest -m "not t4c" tests
       - name: Push
         run: |
           for image in ${{ env.images }}

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -40,9 +40,9 @@ jobs:
       - name: Test readonly image
         run: |
           pip install pytest docker
-          DOCKER_CAPELLA_READONLY="${{ env.registry }}capella/readonly:${{ steps.tag.outputs.branch }}" pytest tests
+          DOCKER_CAPELLA_READONLY="${{ env.registry }}capella/readonly:${{ matrix.capella_version }}-${{ steps.tag.outputs.branch }}" pytest tests
       - name: Push
         run: |
           for image in ${{ env.images }}
-          do docker push ${{ env.registry }}$image:${{ steps.tag.outputs.branch }}
+          do docker push ${{ env.registry }}$image:${{ matrix.capella_version }}-${{ steps.tag.outputs.branch }}
           done

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -4,6 +4,8 @@ name: Push docker images to GitHub container registry
 
 on:
   push:
+  pull_request:
+    branches: [main, staging]
 
 env:
   registry: ghcr.io/dsd-dbs/capella-dockerimages/

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -29,8 +29,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set outputs
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" > $GITHUB_OUTPUTS
       - name: Build
-        run: make ${{ matrix.image }} DOCKER_PREFIX=${{ env.registry }}
+        run: make ${{ matrix.image }} DOCKER_PREFIX=${{ env.registry }} DOCKER_TAG=${{ steps.sha.outputs.short }}
       # - name: Build and push Docker image
       #   id: build-and-push
       #   uses: docker/build-push-action@v3

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -12,7 +12,13 @@ env:
 jobs:
   deploy-docker-images:
     runs-on: ubuntu-latest
-    name: build and push
+    strategy:
+     matrix:
+       capella_version:
+         - "5.0.0"
+         - "5.2.0"
+         - "6.0.0"
+    name: Build image for Capella ${{ matrix.capella_version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -30,7 +36,7 @@ jobs:
         id: tag
         run: echo "branch=$(git rev-parse --abbrev-ref HEAD)" > "$GITHUB_OUTPUT"
       - name: Build
-        run: make ${{ env.images }} DOCKER_PREFIX=${{ env.registry }} DOCKER_TAG=${{ steps.tag.outputs.branch }}
+        run: make ${{ env.images }} CAPELLA_VERSION=${{ matrix.capella_version }} DOCKER_PREFIX=${{ env.registry }} CAPELLA_DOCKERIMAGES_REVISION=${{ steps.tag.outputs.branch }}
       - name: Test readonly image
         run: |
           pip install pytest docker

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -43,14 +43,5 @@ jobs:
         run: |
           pip install pytest docker
           pytest tests
-
-      # - name: Build and push Docker image
-      #   id: build-and-push
-      #   uses: docker/build-push-action@v3
-      #   with:
-      #     context: ${{ matrix.context }}
-      #     tags: ${{ steps.meta.outputs.tags }}
-      #     build-args: |
-      #       ${{ steps.base-image.outputs.build-arg }}
-      #       ${{ matrix.build-args }}
-      #     push: ${{ github.ref == 'refs/heads/main' }}
+      - name: Push
+        run: docker push ${{ env.registry }}${{ matrix.image }}:${{ steps.sha.outputs.short }}

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Test readonly image
         run: |
           pip install pytest docker
-          pytest tests
+          DOCKER_CAPELLA_READONLY="${{ env.registry }}capella/readonly:${{ steps.sha.outputs.short }}" pytest tests
       - name: Push
         run: |
           for image in ${{ env.images }}

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4.3.0
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Login to github container registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -34,6 +34,11 @@ jobs:
         run: echo "short=$(git rev-parse --short HEAD)" > "$GITHUB_OUTPUT"
       - name: Build
         run: make ${{ matrix.image }} DOCKER_PREFIX=${{ env.registry }} DOCKER_TAG=${{ steps.sha.outputs.short }}
+      - name: Test
+        run: |
+          pip install pytest docker
+          pytest tests
+
       # - name: Build and push Docker image
       #   id: build-and-push
       #   uses: docker/build-push-action@v3

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -4,10 +4,9 @@ name: Push docker images to GitHub container registry
 
 on:
   push:
-    branches: [main, staging]
-    tags: ["v*.*.*"]
-  pull_request:
-    branches: [main, staging]
+
+env:
+  registry: ghcr.io/dsd-dbs/capella-dockerimages/
 
 jobs:
   deploy-docker-images:
@@ -16,66 +15,29 @@ jobs:
       fail-fast: true
       max-parallel: 1
       matrix:
-        include:
-          - image: ghcr.io/dsd-dbs/capella-dockerimages/base
-            context: base
-          - image: ghcr.io/dsd-dbs/capella-dockerimages/capella/base
-            context: capella
-            base-image: ghcr.io/dsd-dbs/capella-dockerimages/base
-            build-args: |
-              BUILD_TYPE=online
-              CAPELLA_VERSION=5.2.0
-          - image: ghcr.io/dsd-dbs/capella-dockerimages/capella/ease
-            context: ease
-            base-image: ghcr.io/dsd-dbs/capella-dockerimages/capella/base
-            build-args: |
-              BUILD_TYPE=online
-    name: build and push ${{ matrix.context }}
+        image:
+          - capella/remote
+          - capella/readonly
+          - capella/ease
+    name: build and push ${{ matrix.image }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
       - name: Login to github container registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ matrix.image }}
-          tags: |
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-      - name: Resolve base image
-        # Transform image:tag to BASE_IMAGE=base-image:tag
-        if: ${{ matrix.base-image }}
-        id: base-image
-        run: |
-          export IMAGE=${{ steps.meta.outputs.tags }}
-          export TAG=${IMAGE##*:}
-          echo "::set-output name=build-arg::BASE_IMAGE=${{ matrix.base-image }}:$TAG"
-      - name: Download Capella requirements vp addOn
-        if: ${{ matrix.context == 'capella' }}
-        run: |
-          curl -o req.zip https://download.eclipse.org/capella/addons/requirements/dropins/releases/0.12.3/Requirements-dropins-0.12.3.202208111122.zip;
-          unzip req.zip -d capella/dropins
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@v3
-        with:
-          context: ${{ matrix.context }}
-          tags: ${{ steps.meta.outputs.tags }}
-          build-args: |
-            ${{ steps.base-image.outputs.build-arg }}
-            ${{ matrix.build-args }}
-          push: true
+      - name: Build
+        run: make ${{ matrix.image }} DOCKER_PREFIX=${{ env.registry }}
+      # - name: Build and push Docker image
+      #   id: build-and-push
+      #   uses: docker/build-push-action@v3
+      #   with:
+      #     context: ${{ matrix.context }}
+      #     tags: ${{ steps.meta.outputs.tags }}
+      #     build-args: |
+      #       ${{ steps.base-image.outputs.build-arg }}
+      #       ${{ matrix.build-args }}
+      #     push: ${{ github.ref == 'refs/heads/main' }}

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,8 @@ DOCKER_TAG = $(CAPELLA_VERSION)-$(CAPELLA_DOCKERIMAGES_REVISION)
 # Log level when running Docker containers
 LOG_LEVEL ?= DEBUG
 
+GIT_SHA = $(shell git rev-parse --short HEAD)
+
 all: \
 	base \
 	capella/base \
@@ -100,47 +102,47 @@ base:
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 capella/base: base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(CAPELLA_DOCKERIMAGES_REVISION) --build-arg BUILD_TYPE=$(CAPELLA_BUILD_TYPE) --build-arg CAPELLA_VERSION=$(CAPELLA_VERSION) capella
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(CAPELLA_DOCKERIMAGES_REVISION) --build-arg BUILD_TYPE=$(CAPELLA_BUILD_TYPE) --build-arg CAPELLA_VERSION=$(CAPELLA_VERSION) --label git-short-sha=$(GIT_SHA) capella
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 capella/cli: capella/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) cli
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --label git-short-sha=$(GIT_SHA) cli
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 capella/remote: capella/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) remote
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --label git-short-sha=$(GIT_SHA) remote
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 t4c/client/base: capella/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --build-arg CAPELLA_VERSION=$(CAPELLA_VERSION) t4c
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --build-arg CAPELLA_VERSION=$(CAPELLA_VERSION) --label git-short-sha=$(GIT_SHA) t4c
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 t4c/client/cli: t4c/client/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) cli
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --label git-short-sha=$(GIT_SHA) cli
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 t4c/client/remote: t4c/client/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) remote
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --label git-short-sha=$(GIT_SHA) remote
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 capella/ease: capella/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --build-arg BUILD_TYPE=online ease
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --build-arg BUILD_TYPE=online --label git-short-sha=$(GIT_SHA) ease
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 t4c/client/ease: t4c/client/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --build-arg BUILD_TYPE=online ease
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --build-arg BUILD_TYPE=online --label git-short-sha=$(GIT_SHA) ease
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 capella/ease/remote: capella/ease
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) remote
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --label git-short-sha=$(GIT_SHA) remote
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 capella/readonly: capella/ease/remote
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) readonly
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --label git-short-sha=$(GIT_SHA) readonly
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 t4c/client/backup: t4c/client/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) backups
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --label git-short-sha=$(GIT_SHA) backups
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 run-capella/readonly: capella/readonly

--- a/Makefile
+++ b/Makefile
@@ -102,47 +102,47 @@ base:
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 capella/base: base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(CAPELLA_DOCKERIMAGES_REVISION) --build-arg BUILD_TYPE=$(CAPELLA_BUILD_TYPE) --build-arg CAPELLA_VERSION=$(CAPELLA_VERSION) --label git-short-sha=$(GIT_SHA) capella
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(CAPELLA_DOCKERIMAGES_REVISION) --build-arg BUILD_TYPE=$(CAPELLA_BUILD_TYPE) --build-arg CAPELLA_VERSION=$(CAPELLA_VERSION) capella
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 capella/cli: capella/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --label git-short-sha=$(GIT_SHA) cli
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) cli
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 capella/remote: capella/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --label git-short-sha=$(GIT_SHA) remote
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) remote
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 t4c/client/base: capella/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --build-arg CAPELLA_VERSION=$(CAPELLA_VERSION) --label git-short-sha=$(GIT_SHA) t4c
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --build-arg CAPELLA_VERSION=$(CAPELLA_VERSION) t4c
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 t4c/client/cli: t4c/client/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --label git-short-sha=$(GIT_SHA) cli
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) cli
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 t4c/client/remote: t4c/client/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --label git-short-sha=$(GIT_SHA) remote
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) remote
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 capella/ease: capella/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --build-arg BUILD_TYPE=online --label git-short-sha=$(GIT_SHA) ease
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --build-arg BUILD_TYPE=online ease
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 t4c/client/ease: t4c/client/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --build-arg BUILD_TYPE=online --label git-short-sha=$(GIT_SHA) ease
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --build-arg BUILD_TYPE=online ease
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 capella/ease/remote: capella/ease
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --label git-short-sha=$(GIT_SHA) remote
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) remote
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 capella/readonly: capella/ease/remote
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --label git-short-sha=$(GIT_SHA) readonly
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) readonly
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 t4c/client/backup: t4c/client/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --label git-short-sha=$(GIT_SHA) backups
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) backups
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 run-capella/readonly: capella/readonly

--- a/Makefile
+++ b/Makefile
@@ -100,47 +100,47 @@ base:
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 capella/base: base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)base:$(CAPELLA_DOCKERIMAGES_REVISION) --build-arg BUILD_TYPE=$(CAPELLA_BUILD_TYPE) --build-arg CAPELLA_VERSION=$(CAPELLA_VERSION) capella
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(CAPELLA_DOCKERIMAGES_REVISION) --build-arg BUILD_TYPE=$(CAPELLA_BUILD_TYPE) --build-arg CAPELLA_VERSION=$(CAPELLA_VERSION) capella
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 capella/cli: capella/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)capella/base:$(DOCKER_TAG) cli
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) cli
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 capella/remote: capella/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)capella/base:$(DOCKER_TAG) remote
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) remote
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 t4c/client/base: capella/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)capella/base:$(DOCKER_TAG) --build-arg CAPELLA_VERSION=$(CAPELLA_VERSION) t4c
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --build-arg CAPELLA_VERSION=$(CAPELLA_VERSION) t4c
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 t4c/client/cli: t4c/client/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)t4c/client/base:$(DOCKER_TAG) cli
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) cli
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 t4c/client/remote: t4c/client/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)t4c/client/base:$(DOCKER_TAG) remote
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) remote
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 capella/ease: capella/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)capella/base:$(DOCKER_TAG) --build-arg BUILD_TYPE=online ease
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --build-arg BUILD_TYPE=online ease
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 t4c/client/ease: t4c/client/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)t4c/client/base:$(DOCKER_TAG) --build-arg BUILD_TYPE=online ease
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) --build-arg BUILD_TYPE=online ease
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 capella/ease/remote: capella/ease
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)capella/ease:$(DOCKER_TAG) remote
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) remote
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 capella/readonly: capella/ease/remote
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)capella/ease/remote:$(DOCKER_TAG) readonly
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) readonly
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 t4c/client/backup: t4c/client/base
-	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)t4c/client/base:$(DOCKER_TAG) backups
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(DOCKER_TAG) --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(DOCKER_TAG) backups
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 run-capella/readonly: capella/readonly

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+[pytest]
+markers =
+    t4c: marks tests that require TeamForCapella based docker images

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -28,7 +28,7 @@ def fixture_mode(request) -> str:
     name="container_success",
 )
 def fixture_container_success(
-    mode: str
+    mode: str,
 ) -> Generator[docker.models.containers.Container]:
     env = {
         "json": {
@@ -145,6 +145,7 @@ def test_model_loading(
         assert len(lines(result.output)) == 2
     else:
         assert len(lines(result.output)) == 3
+
 
 def test_invalid_url_fails(
     container_failure: Generator[docker.models.containers.Container],

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -98,6 +98,7 @@ def get_container(
             }
         }
 
+    container = None
     try:
         container = client.containers.run(
             image=os.getenv("DOCKER_CAPELLA_READONLY", "capella/readonly"),
@@ -107,8 +108,9 @@ def get_container(
         )
         yield container
     finally:
-        container.stop()
-        container.remove()
+        if container:
+            container.stop()
+            container.remove()
 
 
 def wait_for_container(container: docker.models.containers.Container) -> None:

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -3,6 +3,7 @@
 
 import json
 import logging
+import os
 import pathlib
 import time
 
@@ -99,7 +100,7 @@ def get_container(
 
     try:
         container = client.containers.run(
-            image="capella/readonly",
+            image=os.getenv("DOCKER_CAPELLA_READONLY", "capella/readonly"),
             detach=True,
             environment=environment | {"RMT_PASSWORD": "password"},
             volumes=volumes,

--- a/tests/test_repositories_seeding.py
+++ b/tests/test_repositories_seeding.py
@@ -117,7 +117,7 @@ def get_container(
     container = None
     try:
         container = client.containers.run(
-            image=os.getenv("DOCKER_CAPELLA_READONLY", "t4c/client/remote"),
+            image=os.getenv("DOCKER_CAPELLA_T4C_REMOTE", "t4c/client/remote"),
             detach=True,
             environment=environment | {"RMT_PASSWORD": "password"},
             volumes=volumes,
@@ -153,6 +153,7 @@ def wait_for_container(container: docker.models.containers.Container) -> None:
         raise TimeoutError("Timeout while waiting for model loading")
 
 
+@pytest.mark.t4c
 def test_repositories_seeding(
     container_success: Generator[docker.models.containers.Container],
     mode: str,
@@ -184,6 +185,7 @@ def test_repositories_seeding(
         assert repositories[key] == re.search(f"{key}=(.+)", file_content).group(1)
 
 
+@pytest.mark.t4c
 def test_invalid_env_variable(
     container_failure: Generator[docker.models.containers.Container],
 ):

--- a/tests/test_repositories_seeding.py
+++ b/tests/test_repositories_seeding.py
@@ -3,6 +3,7 @@
 
 import json
 import logging
+import os
 import pathlib
 import re
 import time
@@ -113,6 +114,7 @@ def get_container(
         if tmp_path
         else {}
     )
+    container = None
     try:
         container = client.containers.run(
             image=os.getenv("DOCKER_CAPELLA_READONLY", "t4c/client/remote"),
@@ -122,8 +124,9 @@ def get_container(
         )
         yield container
     finally:
-        container.stop()
-        container.remove()
+        if container:
+            container.stop()
+            container.remove()
 
 
 def wait_for_container(container: docker.models.containers.Container) -> None:

--- a/tests/test_repositories_seeding.py
+++ b/tests/test_repositories_seeding.py
@@ -115,7 +115,7 @@ def get_container(
     )
     try:
         container = client.containers.run(
-            image="t4c/client/remote",
+            image=os.getenv("DOCKER_CAPELLA_READONLY", "t4c/client/remote"),
             detach=True,
             environment=environment | {"RMT_PASSWORD": "password"},
             volumes=volumes,


### PR DESCRIPTION
Simplify build script and test builds.

* Builds and uploads Capella 5.0, 5.1 and 6.0 (See "packages")
* Builds adds a label with the git hash, so we can always trace a container to the commit
* Runs tests as part of the build
* Builds on every push

Resolves #53 

