### PR TITLE
Use DOCKER_PREFIX and DOCKER_TAG environment for tests

### DIFF
--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -46,10 +46,14 @@ jobs:
           DOCKER_PREFIX=${{ env.registry }}
           CAPELLA_DOCKERIMAGES_REVISION=${{ steps.tag.outputs.branch }}
           DOCKER_BUILD_FLAGS="--label git-short-sha=${{ steps.tag.outputs.sha }}"
-      - name: Test readonly image
+      - name: Install test dependencies
         run: |
           pip install pytest docker
-          DOCKER_CAPELLA_READONLY="${{ env.registry }}capella/readonly:${{ matrix.capella_version }}-${{ steps.tag.outputs.branch }}" pytest -m "not t4c" tests
+      - name: Run pytest
+        run: >
+          DOCKER_PREFIX=${{ env.registry }}
+          DOCKER_TAG=${{ matrix.capella_version }}:${{ steps.tag.outputs.branch }}
+          pytest -m "not t4c" tests
       - name: Push
         run: |
           for image in ${{ env.images }}

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: CC0-1.0
-name: Push docker images to GitHub container registry
+name: Build & push images
 
 on:
   push:
@@ -20,7 +20,7 @@ jobs:
          - "5.0.0"
          - "5.2.0"
          - "6.0.0"
-    name: Build image for Capella ${{ matrix.capella_version }}
+    name: Capella ${{ matrix.capella_version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run pytest
         run: >
           DOCKER_PREFIX=${{ env.registry }}
-          DOCKER_TAG=${{ matrix.capella_version }}:${{ steps.tag.outputs.branch }}
+          DOCKER_TAG=${{ matrix.capella_version }}-${{ steps.tag.outputs.branch }}
           pytest -m "not t4c" tests
       - name: Push
         run: |

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Add prefix to all dockerimage names, e.g. capella-collab
-DOCKER_PREFIX ?=
+export DOCKER_PREFIX ?=
 
 # T4C license secret (usually a long numeric string)
 T4C_LICENCE_SECRET ?= XXX
@@ -76,7 +76,7 @@ PUSH_IMAGES ?= 0
 # Registry to push images
 DOCKER_REGISTRY ?= localhost:12345
 
-DOCKER_TAG = $(CAPELLA_VERSION)-$(CAPELLA_DOCKERIMAGES_REVISION)
+export DOCKER_TAG = $(CAPELLA_VERSION)-$(CAPELLA_DOCKERIMAGES_REVISION)
 
 # Log level when running Docker containers
 LOG_LEVEL ?= DEBUG
@@ -224,6 +224,11 @@ debug-t4c/client/backup: LOG_LEVEL=DEBUG
 debug-t4c/client/backup: DOCKER_RUN_FLAGS=-it --entrypoint="bash" -v $$(pwd)/backups/backup.py:/opt/capella/backup.py
 debug-t4c/client/backup: run-t4c/client/backup
 
+test: capella/readonly t4c/client/remote
+	source .venv/bin/activate
+	cd tests
+	pytest
+
 .push:
 	if [ "$(PUSH_IMAGES)" == "1" ]; \
 	then \
@@ -232,3 +237,4 @@ debug-t4c/client/backup: run-t4c/client/backup
 	fi
 
 .PHONY: *
+.ONESHELL: test

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -91,11 +91,12 @@ def get_container(
 ) -> Generator[docker.models.containers.Container]:
     volumes = {}
     container = None
+    docker_prefix = os.getenv("DOCKER_PREFIX", "")
+    docker_tag = os.getenv("DOCKER_TAG", "latest")
+
     try:
         container = client.containers.run(
-            image=os.getenv("DOCKER_PREFIX", "")
-            + "capella/readonly:"
-            + os.getenv("DOCKER_TAG", "latest"),
+            image=f"{docker_prefix}capella/readonly:{docker_tag}",
             detach=True,
             environment=environment | {"RMT_PASSWORD": "password"},
             volumes=volumes,

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -93,7 +93,9 @@ def get_container(
     container = None
     try:
         container = client.containers.run(
-            image=os.getenv("DOCKER_CAPELLA_READONLY", "capella/readonly"),
+            image=os.getenv("DOCKER_PREFIX", "")
+            + "capella/readonly:"
+            + os.getenv("DOCKER_TAG", "latest"),
             detach=True,
             environment=environment | {"RMT_PASSWORD": "password"},
             volumes=volumes,

--- a/tests/test_repositories_seeding.py
+++ b/tests/test_repositories_seeding.py
@@ -115,11 +115,12 @@ def get_container(
         else {}
     )
     container = None
+    docker_prefix = os.getenv("DOCKER_PREFIX", "")
+    docker_tag = os.getenv("DOCKER_TAG", "latest")
+
     try:
         container = client.containers.run(
-            image=os.getenv("DOCKER_PREFIX", "")
-            + "t4c/client/remote:"
-            + os.getenv("DOCKER_TAG", "latest"),
+            image=f"{docker_prefix}t4c/client/remote:{docker_tag}",
             detach=True,
             environment=environment | {"RMT_PASSWORD": "password"},
             volumes=volumes,

--- a/tests/test_repositories_seeding.py
+++ b/tests/test_repositories_seeding.py
@@ -117,7 +117,9 @@ def get_container(
     container = None
     try:
         container = client.containers.run(
-            image=os.getenv("DOCKER_CAPELLA_T4C_REMOTE", "t4c/client/remote"),
+            image=os.getenv("DOCKER_PREFIX", "")
+            + "t4c/client/remote:"
+            + os.getenv("DOCKER_TAG", "latest"),
             detach=True,
             environment=environment | {"RMT_PASSWORD": "password"},
             volumes=volumes,


### PR DESCRIPTION
Use `DOCKER_PREFIX` and `DOCKER_TAG` environment variables for tests. It allows adding tests without changing the GH actions in the future. 

And it shortens the names of the actions a bit, they were not readable in the commit view: 
![image](https://user-images.githubusercontent.com/23395732/201673464-fc9cb798-9c26-49bc-8b48-0ae1807de396.png)

New: 
![image](https://user-images.githubusercontent.com/23395732/201678462-4ed853cf-8a47-4e44-8c37-f013b7c1cff0.png)

Fixes #61.
