### PR TITLE
Add support for entrypoints starting with /

### DIFF
--- a/capella/setup_workspace.py
+++ b/capella/setup_workspace.py
@@ -32,7 +32,9 @@ def replace_config(path: pathlib.Path, key: str, value: str) -> None:
 if __name__ == "__main__":
     # Disable Welcome Screen
     replace_config(
-        pathlib.Path("/opt/capella/configuration/.settings/org.eclipse.ui.ide.prefs"),
+        pathlib.Path(
+            "/opt/capella/configuration/.settings/org.eclipse.ui.ide.prefs"
+        ),
         "showIntro",
         "false",
     )

--- a/readonly/load_models.py
+++ b/readonly/load_models.py
@@ -91,7 +91,7 @@ def clone_git_model(project: dict[str, str]) -> None:
 def resolve_entrypoint(project: dict[str, str]) -> None:
     if entrypoint := project["entrypoint"]:
         project["location"] = pathlib.Path(
-            project["location"], pathlib.Path(entrypoint).parent
+            project["location"], str(pathlib.Path(entrypoint).parent).lstrip("/")
         )
 
 

--- a/readonly/load_models.py
+++ b/readonly/load_models.py
@@ -91,7 +91,8 @@ def clone_git_model(project: dict[str, str]) -> None:
 def resolve_entrypoint(project: dict[str, str]) -> None:
     if entrypoint := project["entrypoint"]:
         project["location"] = pathlib.Path(
-            project["location"], str(pathlib.Path(entrypoint).parent).lstrip("/")
+            project["location"],
+            str(pathlib.Path(entrypoint).parent).lstrip("/"),
         )
 
 


### PR DESCRIPTION
When starting a read-only session, the entrypoint was not resolved properly. As we explicitly allow entrypoints with `/` (relative to the root of the Git repository), we should have support for it. 

In addition, I added the behavior to the tests.

Resolved #65.