### PR TITLE
Multiple capella versions

### DIFF
--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build
         run: >
           make ${{ env.images }}
-          CAPELLA_VERSION=${{ matrix.capella_version }}
+          CAPELLA_VERSIONS=${{ matrix.capella_version }}
           DOCKER_PREFIX=${{ env.registry }}
           CAPELLA_DOCKERIMAGES_REVISION=${{ steps.tag.outputs.branch }}
           DOCKER_BUILD_FLAGS="--label git-short-sha=${{ steps.tag.outputs.sha }}"

--- a/Makefile
+++ b/Makefile
@@ -257,10 +257,10 @@ test: capella/readonly t4c/client/remote
 	pytest -o log_cli=true -s
 
 .push:
-	if [ "$(PUSH_IMAGES)" == "1" ]; \
+	@if [ "$(PUSH_IMAGES)" == "1" ]; \
 	then \
-		docker tag "$(DOCKER_PREFIX)$(IMAGENAME):$(DOCKER_TAG)" "$(DOCKER_REGISTRY)/$(DOCKER_PREFIX)$(IMAGENAME):$(DOCKER_TAG)"; \
-		docker push "$(DOCKER_REGISTRY)/$(DOCKER_PREFIX)$(IMAGENAME):$(DOCKER_TAG)";\
+		docker tag "$(DOCKER_PREFIX)$(IMAGENAME):$$DOCKER_TAG" "$(DOCKER_REGISTRY)/$(DOCKER_PREFIX)$(IMAGENAME):$$DOCKER_TAG"; \
+		docker push "$(DOCKER_REGISTRY)/$(DOCKER_PREFIX)$(IMAGENAME):$$DOCKER_TAG";\
 	fi
 
 .PHONY: *

--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ debug-t4c/client/backup: run-t4c/client/backup
 test: capella/readonly t4c/client/remote
 	source .venv/bin/activate
 	cd tests
-	pytest
+	pytest -o log_cli=true -s
 
 .push:
 	if [ "$(PUSH_IMAGES)" == "1" ]; \

--- a/capella_loop.sh
+++ b/capella_loop.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-dockerimages contributors
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+# This tries to represent a matrix build
+# When a Make target uses this shell, the target is run for each CAPELLA_VERSION
+# Please make sure to use environment variables instead of Make variables in the targets.
+# This applies to the following variables:
+# - $$CAPELLA_VERSION instead of $(CAPELLA_VERSION)
+# - $$DOCKER_TAG instead of $(DOCKER_TAG)
+
+for version in $CAPELLA_VERSIONS
+do
+    echo "Running target for Capella version $version..."
+    export CAPELLA_VERSION=$version
+    export DOCKER_TAG=$CAPELLA_VERSION-$CAPELLA_DOCKERIMAGES_REVISION
+    /bin/sh "$@"
+    echo "Successfully ran target for Capella version $version."
+done


### PR DESCRIPTION
When you'd like to run tests or build images, please specify the
environment variable CAPELLA_VERSIONS as as comma-separated list of
semantic Capella versions, e.g., "5.0.0 5.2.0 6.0.0"

The environment variable CAPELLA_VERSION is not used anymore for
building or testing images. It is only used to run containers.

As there was no nice way to do it with GNU make, I've defined our own shell.

The result is nice. You can now run `make test` and test against all supported Capella versions.