### PR TITLE
Build capella from source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ capella/versions/*/dropins/*
 capella/.dockerignore
 capella/libs/*
 
+# Capella Builder
+builder/m2_cache
+builder/output
+
 # TeamForCapella
 t4c/updateSite/*/*
 t4c/server

--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,10 @@ t4c/client/backup: t4c/client/base
 	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$$DOCKER_TAG --build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$$DOCKER_TAG --build-arg CAPELLA_VERSION=$$CAPELLA_VERSION backups
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
+capella/builder:
+	docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_PREFIX)$@:$(CAPELLA_DOCKERIMAGES_REVISION) builder
+	docker run -it -e CAPELLA_VERSION=$(CAPELLA_VERSION) -v $$(pwd)/builder/output/$(CAPELLA_VERSION):/output -v $$(pwd)/builder/m2_cache:/root/.m2/repository $(DOCKER_PREFIX)$@:$(CAPELLA_DOCKERIMAGES_REVISION)
+
 run-capella/readonly: capella/readonly
 	docker run $(DOCKER_RUN_FLAGS) \
 		-p $(RDP_PORT):3389 \

--- a/README.md
+++ b/README.md
@@ -714,6 +714,25 @@ We have explicitly observed the following:
   However, in some cases we use caching and in other cases it was not always possible
   to group everything for reasons of clarity.
 
+### Build Capella from source
+
+We provide a script, which runs a Docker container to build Capella from source.
+Our builder script adds the aarch64 build platform for macOS and linux.
+Please note that Capella itself has no official support for the aarch64 architecture yet.
+We can not guarantee that everything works, but all of the official Capella tests passed on the generated archives.
+
+In addition, the builder only works for Capella version 6.0.0 for now.
+To start the script, please run:
+
+```
+CAPELLA_VERSION=6.0.0 make capella/builder
+```
+
+When the script is successful, you should see the result in `builder/output`.
+
+We store a cache of the maven repository in the `builder/m2_cache` directory.
+If you don't need the cache anymore, you can delete the directory after building.
+
 ### Download older packages manually
 
 Unfortunately the version `2.28.1` of `libwebkit2gtk-4.0-37` is no longer available in

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+FROM python:3.11.1-bullseye
+
+RUN apt-get update && \
+    apt-get install -y maven
+
+RUN pip install lxml
+
+COPY inject_architecture_into_pom.py /opt/inject_architecture_into_pom.py
+COPY build_capella_from_source.sh /opt/build_capella_from_source.sh
+
+RUN chmod +x /opt/build_capella_from_source.sh
+
+ENTRYPOINT [ "/opt/build_capella_from_source.sh" ]

--- a/builder/build_capella_from_source.sh
+++ b/builder/build_capella_from_source.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -ex
+
+export CAPELLA_VERSION=${CAPELLA_VERSION:-6.0.0} # Only 6.0.0 supported for now
+
+
+echo "Build for Capella version $CAPELLA_VERSION"
+
+# Clean tmp directory
+mkdir -p /tmp/capella
+cd /tmp/capella
+
+# Print maven version
+mvn --version
+
+# Clone Capella Github repository
+git clone https://github.com/eclipse/capella
+cd capella
+git checkout v$CAPELLA_VERSION
+cd ..
+
+# Install JDK 11
+curl -L -o jdk11-linux.tar.gz https://api.adoptium.net/v3/binary/latest/11/ga/linux/aarch64/jdk/hotspot/normal/eclipse?project=jdk
+tar xf jdk11-linux.tar.gz
+export PATH=$(find /tmp/capella -depth 2 -name "bin"):${PATH}
+
+# Print java version
+java -version
+
+cd capella
+
+# Modify pom.xml and inject architecture
+python /opt/inject_architecture_into_pom.py
+
+# Build Capella
+mvn clean verify -f releng/plugins/org.polarsys.capella.targets/pom.xml
+
+# Inject JRE 17 (Linux)
+curl -L -o linuxJRE.tar.gz https://api.adoptium.net/v3/binary/latest/17/ga/linux/x64/jre/hotspot/normal/eclipse?project=jdk
+mkdir -p linuxJRE/jre
+tar -xf linuxJRE.tar.gz --strip-components 1 -C linuxJRE/jre
+
+# Inject JRE 17 (Linux)
+curl -L -o linuxJRE-aarch64.tar.gz https://api.adoptium.net/v3/binary/latest/17/ga/linux/aarch64/jre/hotspot/normal/eclipse?project=jdk
+mkdir -p linuxJRE-aarch64/jre
+tar -xf linuxJRE-aarch64.tar.gz --strip-components 1 -C linuxJRE-aarch64/jre
+
+# Inject JRE 17 (macOS)
+curl -L -o macJRE.tar.gz https://api.adoptium.net/v3/binary/latest/17/ga/mac/x64/jre/hotspot/normal/eclipse?project=jdk
+mkdir -p macJRE/jre
+tar -xf macJRE.tar.gz --strip-components 1 -C macJRE/jre
+
+# Inject JRE 17 (macOS)
+curl -L -o macJRE-aarch64.tar.gz https://api.adoptium.net/v3/binary/latest/17/ga/mac/aarch64/jre/hotspot/normal/eclipse?project=jdk
+mkdir -p macJRE-aarch64/jre
+tar -xf macJRE-aarch64.tar.gz --strip-components 1 -C macJRE-aarch64/jre
+
+# Inject JRE 17 (Windows)
+curl -L -o winJRE.zip https://api.adoptium.net/v3/binary/latest/17/ga/windows/x64/jre/hotspot/normal/eclipse?project=jdk
+mkdir -p winJRE
+unzip winJRE.zip -d winJRE/jre
+mv winJRE/jre/*/* winJRE/jre
+
+mvn clean verify -f pom.xml -DjavaDocPhase=none -Pfull
+
+mv /tmp/capella/capella/releng/plugins/org.polarsys.capella.rcp.product/target/products /output

--- a/builder/inject_architecture_into_pom.py
+++ b/builder/inject_architecture_into_pom.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+import os
+import pathlib
+
+import lxml
+from lxml import etree
+from lxml.builder import E
+
+
+def patch_root_pom_xml():
+    pom_xml_path = pathlib.Path("pom.xml")
+
+    root = etree.parse(pom_xml_path.open()).getroot()
+    environments = root.xpath("//*[local-name()='environments']")[0]
+    environments.append(
+        E.environment(
+            E.os("linux"),
+            E.ws("gtk"),
+            E.arch("aarch64"),
+        )
+    )
+    environments.append(
+        E.environment(
+            E.os("macosx"),
+            E.ws("cocoa"),
+            E.arch("aarch64"),
+        )
+    )
+    pom_xml_path.write_bytes(etree.tostring(root))
+
+
+def patch_releng_pom_xml():
+    pom_xml_path = pathlib.Path(
+        "releng/plugins/org.polarsys.capella.rcp.product/pom.xml"
+    )
+
+    root = etree.parse(pom_xml_path.open()).getroot()
+
+    create_dropins(root)
+    package_product(root)
+
+    pom_xml_path.write_bytes(etree.tostring(root))
+
+
+def create_dropins(root: etree.ElementTree):
+    # We do the packaging ourselves and don't need antrun
+    create_dropins = root.xpath(
+        "//*[local-name()='execution' and ./*[local-name()='id']/text()='create-dropins']/*[local-name()='configuration']/*[local-name()='target']"
+    )[0]
+    create_dropins.append(
+        E.mkdir(
+            dir="${project.build.directory}/products/org.polarsys.capella.rcp.product/linux/gtk/aarch64/dropins"
+        )
+    )
+    create_dropins.append(
+        E.mkdir(
+            dir="${project.build.directory}/products/org.polarsys.capella.rcp.product/macosx/cocoa/aarch64/Capella.app/Contents/Eclipse/dropins"
+        )
+    )
+
+
+def package_product(root: etree.ElementTree):
+    target = root.xpath(
+        "//*[local-name()='execution' and ./*[local-name()='id']/text()='package-product']/*[local-name()='configuration']/*[local-name()='target']"
+    )[0]
+
+    existing_packages = {
+        "linux": {
+            "move": "${project.build.directory}/products/org.polarsys.capella.rcp.product/linux/gtk/x86_64/jre",
+            "tar": "${project.build.directory}/products/capella-${unqualifiedVersion}.${buildQualifier}-linux-gtk-x86_64.tar.gz",
+        },
+        "macos": {
+            "move": "${project.build.directory}/products/org.polarsys.capella.rcp.product/macosx/cocoa/x86_64/Capella.app/Contents/jre",
+            "tar": "${project.build.directory}/products/capella-${unqualifiedVersion}.${buildQualifier}-macosx-cocoa-x86_64.tar.gz",
+        },
+    }
+
+    for package in existing_packages.values():
+        move_todir = package["move"]
+        move = target.xpath(
+            f"./*[local-name()='move' and ./@todir='{move_todir}']"
+        )[0]
+
+        copied_move = copy.deepcopy(move)
+        copied_move.attrib["todir"] = move_todir.replace("x86_64", "aarch64")
+        fileset = copied_move.getchildren()[0]
+        fileset.attrib["dir"] = fileset.attrib["dir"].replace(
+            "JRE", "JRE-aarch64"
+        )
+
+        target.append(copied_move)
+
+        tar_destfile = package["tar"]
+        tar = target.xpath(
+            f"./*[local-name()='tar' and ./@destfile='{tar_destfile}']"
+        )[0]
+
+        copied_tar = copy.deepcopy(tar)
+        copied_tar.attrib["destfile"] = copied_tar.attrib["destfile"].replace(
+            "x86_64", "aarch64"
+        )
+        for tarfileset in copied_tar.getchildren():
+            tarfileset.attrib["dir"] = tarfileset.attrib["dir"].replace(
+                "x86_64", "aarch64"
+            )
+
+        target.append(copied_tar)
+
+
+if __name__ == "__main__":
+    patch_root_pom_xml()
+    patch_releng_pom_xml()


### PR DESCRIPTION
Adds a script + Docker image + README section to build Capella from source (including `aarch64` support).