### PR TITLE
Comment out default values for environment variables

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: CC0-1.0
+
+*   @MoritzWeber0

--- a/ci-templates/gitlab/README.md
+++ b/ci-templates/gitlab/README.md
@@ -10,6 +10,7 @@ Currently, we provide the following Gitlab CI/CD templates:
 - [Export to T4C](#export-to-t4c): Export model in repository to T4C using the merge strategy
 - [Diagram cache](#diagram-cache): Export diagrams of a Capella model and store them in Gitlab artifacts
 - [Image builder](#image-builder): Build and push all Docker images to any Docker registry.
+- [Model validation](#model-validation): Runs the Capella model validation CLI tool.
 
 ## Export to T4C
 
@@ -133,3 +134,24 @@ The tree inside of your Gitlab repository should look like:
 
 This is the minimal configuration. For more advanced configuration options,
 please refer to the [Gitlab CI template](./image-builder.yml).
+
+## Model validation
+
+Currently, the model validation does NOT support:
+
+- Loading of Capella libraries (only Capella projects without libraries are supported)
+- Usage of subdirectories with the `$ENTRYPOINT`. The `.aird`-file has to be located in the root directory of the repository.
+- Projects without `.project`-file. The `.project` has to be located in the root directory of the repository.
+
+Please add the following section to your `.gitlab-ci.yml`:
+
+```yml
+variables:
+  CAPELLA_VERSION: 6.0.0 # Enter the Capella version of the model here, only versions >= 6.0.0 are supported
+  ENTRYPOINT: test.aird # Filename of the `.aird` file
+
+include:
+  - remote: https://raw.githubusercontent.com/DSD-DBS/capella-dockerimages/${CAPELLA_DOCKER_IMAGES_REVISION}/ci-templates/gitlab/model-validation.yml
+```
+
+For more information, please refer to the [Gitlab CI template](./model-validation.yml).

--- a/ci-templates/gitlab/exporter.yml
+++ b/ci-templates/gitlab/exporter.yml
@@ -36,34 +36,34 @@ export-to-t4c:
     # ENTRYPOINT: null
 
     # Required: Hostname of T4C server
-    T4C_REPO_HOST: ${T4C_REPO_HOST}
+    # T4C_REPO_HOST: ${T4C_REPO_HOST}
 
     # Port of repository endpoint to the T4C server
     # Defaults to 2036
-    T4C_REPO_PORT: 2036
+    # T4C_REPO_PORT: 2036
 
     # Required: T4C project name
-    T4C_PROJECT_NAME: ${T4C_PROJECT_NAME}
+    # T4C_PROJECT_NAME: ${T4C_PROJECT_NAME}
 
     # Required: T4C repository name
-    T4C_REPO_NAME: ${T4C_REPO_NAME}
+    # T4C_REPO_NAME: ${T4C_REPO_NAME}
 
     # T4C username (for repository login)
     # The user needs access to the specific repository
-    T4C_USERNAME: ${T4C_USERNAME}
+    # T4C_USERNAME: ${T4C_USERNAME}
 
     # T4C password (for repository login)
-    T4C_PASSWORD: ${T4C_PASSWORD}
+    # T4C_PASSWORD: ${T4C_PASSWORD}
 
     # HTTP username
-    HTTP_LOGIN: ${HTTP_LOGIN}
+    # HTTP_LOGIN: ${HTTP_LOGIN}
 
     # HTTP password
-    HTTP_PASSWORD: ${HTTP_PASSWORD}
+    # HTTP_PASSWORD: ${HTTP_PASSWORD}
 
     # HTTP Port (port for REST API endpoint)
     # Defaults to 8080
-    HTTP_PORT: 8080
+    # HTTP_PORT: 8080
 
     # Log level. All Python `logging` levels are allowed.
     # Defaults to INFO

--- a/ci-templates/gitlab/model-validation.yml
+++ b/ci-templates/gitlab/model-validation.yml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+model-validation:
+  image:
+    name: $DOCKER_REGISTRY/capella/cli:${CAPELLA_DOCKER_IMAGES_TAG}
+    entrypoint: [""]
+  script:
+    - git fetch
+    - if [ ! -z $CI_COMMIT_BRANCH ]; then git reset --hard origin/$CI_COMMIT_BRANCH; fi
+    - BUILD_DIR=$(pwd)
+    - if [ ! -f ".project" ]; then echo "The model validator requires a '.project' file!" && exit 1; fi
+    - if [[ "$(dirname $ENTRYPOINT)" != "." ]]; then echo 'The model validator requires a "*.aird" in the root level of the repository!' && exit 1; fi
+    - mkdir /tmp/project
+    - cp -r . /tmp/project
+    - cd /tmp
+    - >
+      xvfb-run /opt/capella/capella
+      -nosplash
+      -application org.polarsys.capella.core.commandline.core
+      -appid org.polarsys.capella.core.validation.commandline
+      -data "$(pwd)"
+      -input "project/$ENTRYPOINT"
+      -outputfolder "project/validation"
+    - cp /tmp/project/validation/project/$ENTRYPOINT/validation-results.html $BUILD_DIR
+  artifacts:
+    paths:
+      - "validation-results.html"
+  variables:
+    # Virtual display used to run Capella in the background.
+    # Do not modify the value!
+    DISPLAY: ":99"
+
+    # Docker tag, which is used for the capella/cli image.
+    # Defaults to ${CAPELLA_VERSION}-${CAPELLA_DOCKER_IMAGES_REVISION} if not defined
+    CAPELLA_DOCKER_IMAGES_TAG: ${CAPELLA_VERSION}-${CAPELLA_DOCKER_IMAGES_REVISION}


### PR DESCRIPTION
Otherwise, environment variables are used as default when they are not defined. The script doesn't fail. This is unintended behaviour.