### PR TITLE
Do not add whitespace after the comma

### DIFF
--- a/t4c/patch_t4c.sh
+++ b/t4c/patch_t4c.sh
@@ -6,7 +6,7 @@ if [[ -n "/opt/updateSite/patch_info.csv" ]];
 then
     while IFS="," read -r t4c_patch_zip install_iu tag
     do
-        INSTALL_IU_JOIN=$(echo $install_iu | sed "s/ /, /g");
+        INSTALL_IU_JOIN=$(echo $install_iu | sed "s/ /,/g");
         /opt/capella/capella \
         -consoleLog \
         -application org.eclipse.equinox.p2.director \


### PR DESCRIPTION
Fix for functionality added in #118 needed since the `installIU` list is not allowed to have whitespaces in it.