### PR TITLE
Add `git-lfs` to base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
     locales \
     python3 \
     python3-pip \
+    git-lfs \
     unzip \
     zip && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Git is commonly used in CI/CD environments.