### PR TITLE
Add release train Gitlab CI template

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,59 @@
+include: "/ci-templates/gitlab/release-train.yml"
+
+.staging: &staging
+  rules:
+    # For commits on the main branch, build for the staging environment
+    - if: '$CI_COMMIT_REF_NAME == "main"'
+    - when: manual
+  variables:
+    ENVIRONMENT: staging
+    CAPELLA_DOCKER_IMAGES_REVISION: "$CI_COMMIT_REF_NAME"
+    IMAGE_BUILDER_GITLAB_REPOSITORY: "$IMAGE_BUILDER_GITLAB_REPOSITORY"
+    BUILD_FOR_LATEST_TAG: "0"
+    DOCKER_BUILD_ARGS: "" # Enable Docker build cache
+
+.production: &production
+  rules:
+    # For tags, build for the production environment
+    - if: "$CI_COMMIT_TAG != null"
+  variables:
+    ENVIRONMENT: production
+    CAPELLA_DOCKER_IMAGES_REVISION: "$CI_COMMIT_REF_NAME"
+    IMAGE_BUILDER_GITLAB_REPOSITORY: "$IMAGE_BUILDER_GITLAB_REPOSITORY"
+    BUILD_FOR_LATEST_TAG: "1"
+
+production-base:
+  extends: .base
+  <<: *production
+
+production-jupyter:
+  extends: .jupyter
+  needs:
+    - job: production-base
+      optional: true
+  <<: *production
+
+production-capella:
+  extends: .capella
+  needs:
+    - job: production-base
+      optional: true
+  <<: *production
+
+staging-base:
+  extends: .base
+  <<: *staging
+
+staging-jupyter:
+  extends: .jupyter
+  needs:
+    - job: staging-base
+      optional: true
+  <<: *staging
+
+staging-capella:
+  extends: .capella
+  needs:
+    - job: staging-base
+      optional: true
+  <<: *staging

--- a/.gitlab-ci.yml.license
+++ b/.gitlab-ci.yml.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+SPDX-License-Identifier: Apache-2.0

--- a/ci-templates/gitlab/image-builder.yml
+++ b/ci-templates/gitlab/image-builder.yml
@@ -3,40 +3,40 @@
 
 variables:
   BASE:
-    value: "1"
+    value: "0"
     description: "Build the base image?"
   CAPELLA_BASE:
-    value: "1"
+    value: "0"
     description: "Build the capella/base image?"
   CAPELLA_CLI:
-    value: "1"
+    value: "0"
     description: "Build the capella/cli image?"
   CAPELLA_REMOTE:
     value: "0"
     description: "Build the capella/remote image?"
   T4C_CLIENT_BASE:
-    value: "1"
+    value: "0"
     description: "Build the t4c/client/base image?"
   T4C_CLIENT_BACKUP:
-    value: "1"
+    value: "0"
     description: "Build the t4c/client/backup image?"
   T4C_CLIENT_EXPORTER:
-    value: "1"
+    value: "0"
     description: "Build the t4c/client/exporter image?"
   T4C_CLIENT_REMOTE:
-    value: "1"
+    value: "0"
     description: "Build the t4c/client/remote image?"
   T4C_CLIENT_REMOTE_PURE_VARIANTS:
-    value: "1"
+    value: "0"
     description: "Build the t4c/client/remote/pure-variants image?"
   CAPELLA_EASE:
-    value: "1"
+    value: "0"
     description: "Build the capella/ease image?"
   CAPELLA_EASE_REMOTE:
-    value: "1"
+    value: "0"
     description: "Build the capella/ease/remote image?"
   CAPELLA_READONLY:
-    value: "1"
+    value: "0"
     description: "Build the capella/readonly image?"
   T4C_CLIENT_EASE:
     value: "0"
@@ -56,6 +56,9 @@ variables:
   CAPELLA_VERSION:
     value: "6.0.0"
     description: "Capella version. Please make sure that a subdirectory with the name of the value exists. The value must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes."
+  BUILD_FOR_LATEST_TAG:
+    value: "0"
+    description: "Fetch the latest tag for the image builder repository and use it as revision. If 0, '$CI_COMMIT_REF_NAME' will be used."
   JUPYTER_VERSION:
     value: "python-3.11"
     description: "Python version for the jupyter notebook."
@@ -75,7 +78,15 @@ default:
   tags:
     - docker
   before_script:
-    - &baseImageTag export BASE_IMAGE_TAG=$(echo $CAPELLA_DOCKER_IMAGES_REVISION | sed 's/[^a-zA-Z0-9.]/-/g')-$CI_COMMIT_REF_NAME
+    - &imageBuilderRevision >
+      if [[ "$BUILD_FOR_LATEST_TAG" == "1" ]]; then
+        git fetch --tags;
+        IMAGE_BUILDER_REVISION=$(git describe --tags --abbrev=0);
+        git checkout "$IMAGE_BUILDER_REVISION";
+      else
+        IMAGE_BUILDER_REVISION="$CI_COMMIT_REF_NAME"
+      fi
+    - &baseImageTag export BASE_IMAGE_TAG=$(echo $CAPELLA_DOCKER_IMAGES_REVISION | sed 's/[^a-zA-Z0-9.]/-/g')-$IMAGE_BUILDER_REVISION
     - export DOCKER_TAG=$CAPELLA_VERSION-$BASE_IMAGE_TAG
     - >
       if [[ "$BASE_IMAGE" == "$DOCKER_REGISTRY/base2" ]]; then
@@ -91,7 +102,7 @@ default:
 
 .docker: &docker
   - docker info
-  - docker login -u $DOCKER_REGISTRY_USER -p $DOCKER_REGISTRY_PASSWORD $DOCKER_REGISTRY
+  - echo $DOCKER_REGISTRY_PASSWORD | docker login -u $DOCKER_REGISTRY_USER --password-stdin $DOCKER_REGISTRY
   - docker pull $BASE_IMAGE
 
 .push: &push
@@ -142,6 +153,7 @@ base:
     BASE_IMAGE: debian:bullseye
     IMAGE: $DOCKER_REGISTRY/base2
   before_script:
+    - *imageBuilderRevision
     - *baseImageTag
     - export DOCKER_TAG=$BASE_IMAGE_TAG
   script:

--- a/ci-templates/gitlab/release-train.yml
+++ b/ci-templates/gitlab/release-train.yml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+variables:
+  # Revision of Github repository. If using a mirror, no change is needed.
+  CAPELLA_DOCKER_IMAGES_REVISION: "$CI_COMMIT_REF_NAME"
+
+  # Provide the path to image builder repository
+  IMAGE_BUILDER_GITLAB_REPOSITORY: "path/to/project"
+
+# The base image does not depend on the Capella version.
+# Therefore, we're building it once before building the dependent Capella images.
+.base:
+  trigger:
+    project: "$IMAGE_BUILDER_GITLAB_REPOSITORY"
+    strategy: depend
+  variables:
+    CAPELLA_DOCKER_IMAGES_REVISION: $CAPELLA_DOCKER_IMAGES_REVISION
+    BUILD_FOR_LATEST_TAG: "1"
+
+    # Only build base image
+    BASE: "1"
+
+.capella:
+  trigger:
+    project: "$IMAGE_BUILDER_GITLAB_REPOSITORY"
+    strategy: depend
+  parallel:
+    matrix:
+      - CAPELLA_VERSION: ["5.0.0", "5.2.0", "6.0.0", "6.1.0"]
+  variables:
+    CAPELLA_DOCKER_IMAGES_REVISION: $CAPELLA_DOCKER_IMAGES_REVISION
+    BUILD_FOR_LATEST_TAG: "1"
+
+    # Build all Capella images
+    CAPELLA_BASE: "1"
+    CAPELLA_CLI: "1"
+    CAPELLA_REMOTE: "1"
+    T4C_CLIENT_BASE: "1"
+    T4C_CLIENT_BACKUP: "1"
+    T4C_CLIENT_EXPORTER: "1"
+    T4C_CLIENT_REMOTE: "1"
+    T4C_CLIENT_REMOTE_PURE_VARIANTS: "1"
+    CAPELLA_EASE: "1"
+    CAPELLA_EASE_REMOTE: "1"
+    CAPELLA_READONLY: "1"
+
+.jupyter:
+  trigger:
+    project: "$IMAGE_BUILDER_GITLAB_REPOSITORY"
+    strategy: depend
+  variables:
+    CAPELLA_DOCKER_IMAGES_REVISION: $CAPELLA_DOCKER_IMAGES_REVISION
+    BUILD_FOR_LATEST_TAG: "1"
+
+    # Only build jupyter image
+    JUPYTER: "1"

--- a/docs/docs/ci-templates/gitlab/release-train.md
+++ b/docs/docs/ci-templates/gitlab/release-train.md
@@ -1,0 +1,88 @@
+<!--
+ ~ SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+ ~ SPDX-License-Identifier: Apache-2.0
+ -->
+
+# Release train
+
+The image builder Gitlab CI/CD template is limited to one environment and one Capella version.
+In addition, we provide a release train template, which can be used to trigger the image builder pipeline with a matrix of Capella versions and environments.
+
+<!-- prettier-ignore -->
+!!! warning
+    To continue, create a new image builder Gitlab repository and follow the instuctions of the image builder template.
+
+The pipeline is not triggered automatically. There are a few options to trigger the pipeline automatically:
+
+For changes on Github in this repository (e.g., new push to branches or a new tag):
+
+- If you're using the PREMIUM version of Gitlab, pipelines can be automatically triggered for external repositories: https://docs.gitlab.com/ee/ci/ci_cd_for_external_repos/
+- Detect changes on the remote with `git ls-remote` and trigger a Gitlab CI pipeline with a cronjob.
+
+For changes in your Gitlab image builder repository:
+
+- Use a [Gitlab trigger](https://docs.gitlab.com/ee/ci/yaml/#trigger) to trigger the release train pipeline.
+
+You can customize the pipeline to your needs (e.g., define multiple environments). The template provides three different jobs `.base`, `.capella` and `.jupyter` which can be extended:
+
+```yml
+include:
+  - remote: https://raw.githubusercontent.com/DSD-DBS/capella-dockerimages/${CAPELLA_DOCKER_IMAGES_REVISION}/ci-templates/gitlab/release-train.yml"
+
+.staging: &staging
+  rules:
+    # For commits on the main branch, build for the staging environment
+    - if: '$CI_COMMIT_REF_NAME == "main"'
+    - when: manual
+  variables:
+    ENVIRONMENT: staging
+    CAPELLA_DOCKER_IMAGES_REVISION: "$CI_COMMIT_REF_NAME"
+    IMAGE_BUILDER_GITLAB_REPOSITORY: "$IMAGE_BUILDER_GITLAB_REPOSITORY"
+    BUILD_FOR_LATEST_TAG: "0"
+
+.production: &production
+  rules:
+    # For tags, build for the production environment
+    - if: "$CI_COMMIT_TAG != null"
+  variables:
+    ENVIRONMENT: production
+    CAPELLA_DOCKER_IMAGES_REVISION: "$CI_COMMIT_REF_NAME"
+    IMAGE_BUILDER_GITLAB_REPOSITORY: "$IMAGE_BUILDER_GITLAB_REPOSITORY"
+    BUILD_FOR_LATEST_TAG: "1"
+
+production-base:
+  extends: .base
+  <<: *production
+
+production-jupyter:
+  extends: .jupyter
+  needs:
+    - job: production-base
+      optional: true
+  <<: *production
+
+production-capella:
+  extends: .capella
+  needs:
+    - job: production-base
+      optional: true
+  <<: *production
+
+staging-base:
+  extends: .base
+  <<: *staging
+
+staging-jupyter:
+  extends: .jupyter
+  needs:
+    - job: staging-base
+      optional: true
+  <<: *staging
+
+staging-capella:
+  extends: .capella
+  needs:
+    - job: staging-base
+      optional: true
+  <<: *staging
+```


### PR DESCRIPTION
Adds the release train Gitlab CI template. With the release train, users can build images for new Capella versions on a specific trigger (e.g. manual trigger, on new releases or new Capella archives).

- [ ] Update internal documentation after this PR is merged.