### PR TITLE
feat: Add VNC as supported connection protocol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,9 @@ GIT_PASSWORD ?= password
 # Preferred RDP port on your host system
 RDP_PORT ?= 3390
 
+# Preferred VNC port on your host system
+VNC_PORT ?= 5900
+
 # Preferred metrics port on your host system
 METRICS_PORT ?= 9118
 
@@ -260,6 +263,14 @@ capella/builder:
 run-capella/base: capella/base
 	docker run $(DOCKER_RUN_FLAGS) \
 		$(DOCKER_PREFIX)capella/base:$$(echo "$(DOCKER_TAG_SCHEMA)" | envsubst)
+
+run-capella/remote: capella/remote
+	docker run $(DOCKER_RUN_FLAGS) \
+		-e RMT_PASSWORD=$(RMT_PASSWORD) \
+		-p $(RDP_PORT):3389 \
+		-p $(VNC_PORT):5900 \
+		-p $(METRICS_PORT):9118 \
+		$(DOCKER_PREFIX)capella/remote:$$(echo "$(DOCKER_TAG_SCHEMA)" | envsubst)
 
 run-capella/readonly: capella/readonly
 	docker run $(DOCKER_RUN_FLAGS) \

--- a/remote/Dockerfile
+++ b/remote/Dockerfile
@@ -20,6 +20,8 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     obconf \
     gettext-base \
     xprintidle \
+    x11vnc \
+    xvfb \
     nitrogen && rm -rf /var/lib/apt/lists/*
 
 COPY rc.xml /etc/xdg/openbox/rc.xml

--- a/remote/autostart
+++ b/remote/autostart
@@ -5,6 +5,7 @@
 # Autostart script for OpenBox
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export DISPLAY=:99
 
 nitrogen --restore &
 

--- a/remote/startup.sh
+++ b/remote/startup.sh
@@ -24,4 +24,8 @@ done
 # Replace environment variables in capella.ini, e.g. licences
 envsubst < /opt/capella/capella.ini > /tmp/capella.ini && mv /tmp/capella.ini /opt/capella/capella.ini;
 
+mkdir ~/.vnc
+echo $RMT_PASSWORD > ~/.vnc/passwdfile
+
+Xvfb :99 -screen 0 1920x1080x8 -nolisten tcp &
 exec supervisord

--- a/remote/supervisord.conf
+++ b/remote/supervisord.conf
@@ -12,6 +12,11 @@ user=techuser
 autorestart=true
 environment=DISPLAY=":10"
 
+[program:x11vnc]
+command=x11vnc -usepw -display :99
+user=techuser
+autorestart=true
+
 [program:idletime]
 ; Return idle time of xserver in seconds from xprintidle
 command=python .metrics.py


### PR DESCRIPTION
This PR is very much WIP. Capella has not started during my experiments, but the display seemed to work in general, I could display some elements via `tkinter`.