### PR TITLE
Bash default shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ export DOCKER_BUILDKIT=1
 export MAKE_CURRENT_TARGET=$@
 
 .ONESHELL:
+SHELL=/bin/bash
 
 all: \
 	base \

--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,13 @@ run-capella/base: capella/base
 	docker run $(DOCKER_RUN_FLAGS) \
 		$(DOCKER_PREFIX)capella/base:$$(echo "$(DOCKER_TAG_SCHEMA)" | envsubst)
 
+run-capella/remote: capella/remote
+	docker run $(DOCKER_RUN_FLAGS) \
+		-e RMT_PASSWORD=$(RMT_PASSWORD) \
+		-p $(RDP_PORT):3389 \
+		-p $(METRICS_PORT):9118 \
+		$(DOCKER_PREFIX)capella/remote:$$(echo "$(DOCKER_TAG_SCHEMA)" | envsubst)
+
 run-capella/readonly: capella/readonly
 	docker run $(DOCKER_RUN_FLAGS) \
 		-p $(RDP_PORT):3389 \

--- a/capella_loop.sh
+++ b/capella_loop.sh
@@ -5,7 +5,7 @@
 set -e
 
 # This tries to represent a matrix build
-# When a Make target uses this shell, the target is run for each CAPELLA_VERSION
+# When a Make target uses this shell, the target runs for each CAPELLA_VERSION
 # Please make sure to use environment variables instead of Make variables in the targets.
 # This applies to the following variables:
 # - $$CAPELLA_VERSION instead of $(CAPELLA_VERSION)


### PR DESCRIPTION
We do only support `/bin/bash`, but it was not set as default.
If the SHELL was not set on the target, it has used the system shell
as fallback. This can also be `/bin/sh` or any other shell,
which we don't support. This can lead to errors when running Make
targets on these systems.

Thanks to @vik378 for finding the issue.

This PR sets `bash` as global default shell.

In addition, the `run-capella/remote` has been added.