### PR TITLE
Upgrade to Debian Bookworm

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-ARG BASE_IMAGE=debian:bookworm
+ARG BASE_IMAGE=debian:bookworm-slim
 FROM $BASE_IMAGE
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-ARG BASE_IMAGE=debian:bullseye
+ARG BASE_IMAGE=debian:bookworm
 FROM $BASE_IMAGE
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -10,7 +10,7 @@ ENV SHELL=/bin/bash
 RUN apt-get update && \
     apt-get install -y maven
 
-RUN pip install lxml
+RUN pip install --break-system-packages lxml
 
 COPY inject_architecture_into_pom.py /opt/inject_architecture_into_pom.py
 COPY build_capella_from_source.sh /opt/build_capella_from_source.sh

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11.1-bullseye
+FROM python:3.11.1-bookworm
 
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]

--- a/capella/Dockerfile
+++ b/capella/Dockerfile
@@ -55,7 +55,7 @@ FROM base_new as build_online
 # https://github.com/moby/moby/issues/26533#issuecomment-246966836
 ONBUILD ARG CAPELLA_VERSION="5.2.0"
 ONBUILD COPY ./download_archive.py /opt/.download_archive.py
-ONBUILD RUN pip install requests lxml && \
+ONBUILD RUN pip install --break-system-packages requests lxml && \
     python .download_archive.py ${CAPELLA_VERSION};
 
 FROM base_new as build_offline
@@ -108,7 +108,7 @@ COPY install_dropins.py /opt/install_dropins.py
 COPY ./versions/${CAPELLA_VERSION}/dropins.yml /opt/dropins.yml
 RUN echo '-Dorg.eclipse.equinox.p2.transport.ecf.retry=15' >> /opt/capella/capella.ini
 RUN echo '-Dorg.eclipse.ecf.provider.filetransfer.retrieve.readTimeout=10000' >> /opt/capella/capella.ini
-RUN pip install PyYAML && python install_dropins.py
+RUN pip install --break-system-packages PyYAML && python install_dropins.py
 
 COPY ./versions/${CAPELLA_VERSION}/patches /opt/patches
 RUN PATCH_DIR=/opt/patches /opt/patch.sh

--- a/ci-templates/gitlab/diagram-cache.yml
+++ b/ci-templates/gitlab/diagram-cache.yml
@@ -9,7 +9,7 @@ update_capella_diagram_cache:
     name: $DOCKER_REGISTRY/capella/base:${CAPELLA_DOCKER_IMAGES_TAG}
     entrypoint: [""]
   script:
-    - pip install capellambse
+    - pip install --break-system-packages capellambse
     - mkdir diagram_cache
     - |
       xvfb-run python <<EOF

--- a/ci-templates/gitlab/image-builder.yml
+++ b/ci-templates/gitlab/image-builder.yml
@@ -80,7 +80,7 @@ variables:
   T4C_SERVER_REGISTRY: "" # Registry where you can find the t4c server image
   T4C_SERVER_TAG: "$CAPELLA_VERSION-main" # Tag that is used for the t4c server image
   T4C_SERVER_TEST_DATA_REPO: "" # Link to the t4c test data repo needed to run the backup tests
-  LOCAL_GIT_BASE_IMAGE: "debian:bullseye" # Specifies the base images used to build the local git server needed to run the tests
+  LOCAL_GIT_BASE_IMAGE: "debian:bookworm" # Specifies the base images used to build the local git server needed to run the tests
   DOCKER_BUILD_ARGS: "--no-cache"
   BUILD_ARCHITECTURE: amd64
   PURE_VARIANTS_VERSION: "6.0.1"
@@ -193,7 +193,7 @@ base:
     - if: '$BASE == "1"'
       when: always
   variables:
-    BASE_IMAGE: debian:bullseye
+    BASE_IMAGE: debian:bookworm
     IMAGE: base2
   script:
     - *prepare

--- a/docs/docs/base.md
+++ b/docs/docs/base.md
@@ -50,7 +50,7 @@ docker build -t base --build-arg BASE_IMAGE=$CUSTOM_IMAGE base
 
 Make sure that your `$CUSTOM_IMAGE` is a Linux image that has the common tools installed
 and uses the `apt` / `apt-get` package manager. If this is not the case, the image
-can not be used. Our images were tested with the image `debian:bullseye`.
+can not be used. Our images were tested with the image `debian:bookworm`.
 
 If you like to set a custom `UID` for the user `techuser`, you can run:
 

--- a/ease/Dockerfile
+++ b/ease/Dockerfile
@@ -17,8 +17,7 @@ RUN apt-get update && \
     xvfb \
     dbus-x11 \
     git-lfs && \
-    ca-certificates-java \
-    openjdk-17-jre \
+    ( apt install -y openjdk-17-jre || apt install -y openjdk-17-jre ) && \
     rm -rf /var/lib/apt/lists/*
 
 ARG GIT_EMAIL=contact@example.com

--- a/ease/Dockerfile
+++ b/ease/Dockerfile
@@ -9,13 +9,15 @@ FROM $BASE_IMAGE as prebuild
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 ENV SHELL=/bin/bash
 
+# Somehow OpenJDK does not install in one shot due to a (cyclic?) dependency on
+# package ca-certificates-java. Performing the install again fixes it.
 RUN apt-get update && \
     apt-get install -y \
-    openjdk-17-jre \
     xdg-utils \
     xvfb \
     dbus-x11 \
     git-lfs && \
+    ( apt install -y openjdk-17-jre || apt install -y openjdk-17-jre ) && \
     rm -rf /var/lib/apt/lists/*
 
 ARG GIT_EMAIL=contact@example.com

--- a/ease/Dockerfile
+++ b/ease/Dockerfile
@@ -27,7 +27,7 @@ RUN git config --global user.name $GIT_USERNAME && \
 # Use Virtual Display
 ENV DISPLAY :99
 
-RUN pip install py4j
+RUN pip install --break-system-packages py4j
 
 # Offline build (fixed version)
 FROM prebuild as build_offline
@@ -90,7 +90,7 @@ USER root
 RUN rm -rf /tmp/extensions
 RUN echo "-Dorg.eclipse.swtbot.search.timeout=1000" >> /opt/capella/capella.ini
 
-RUN pip install pyease
+RUN pip install --break-system-packages pyease
 
 ENV EASE_WORKSPACE /workspace
 ENV EASE_SCRIPTS_LOCATION /opt/scripts

--- a/ease/Dockerfile
+++ b/ease/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update && \
     xvfb \
     dbus-x11 \
     git-lfs && \
-    ( apt install -y openjdk-17-jre || apt install -y openjdk-17-jre ) && \
+    ca-certificates-java \
+    openjdk-17-jre \
     rm -rf /var/lib/apt/lists/*
 
 ARG GIT_EMAIL=contact@example.com

--- a/jupyter-notebook/Dockerfile
+++ b/jupyter-notebook/Dockerfile
@@ -18,7 +18,7 @@ COPY docker-entrypoint.sh /
 COPY requirements_template.txt /etc/skel
 
 RUN chmod +x /docker-entrypoint.sh && \
-    python3 -m pip install jupyterlab capellambse && \
+    python3 -m pip install --break-system-packages jupyterlab capellambse && \
     jupyter labextension disable @jupyterlab/extensionmanager-extension
 
 ENV JUPYTER_PORT=8888

--- a/jupyter-notebook/docker-entrypoint.sh
+++ b/jupyter-notebook/docker-entrypoint.sh
@@ -8,7 +8,7 @@ echo "---START_PREPARE_WORKSPACE---"
 mkdir -p "$NOTEBOOKS_DIR"
 
 test -f "$NOTEBOOKS_DIR/requirements.txt" || cp /etc/skel/requirements_template.txt "$NOTEBOOKS_DIR/requirements.txt"
-pip install -r "$NOTEBOOKS_DIR/requirements.txt" 2>&1 | tee "$NOTEBOOKS_DIR/installlog.txt"
+pip install --break-system-packages -r "$NOTEBOOKS_DIR/requirements.txt" 2>&1 | tee "$NOTEBOOKS_DIR/installlog.txt"
 
 echo "---START_SESSION---"
 

--- a/readonly/Dockerfile
+++ b/readonly/Dockerfile
@@ -9,7 +9,7 @@ ENV SHELL=/bin/bash
 
 USER root
 
-RUN pip install lxml
+RUN pip install --break-system-packages lxml
 COPY load_models.py /opt/scripts/load_models.py
 RUN chown -R techuser /opt/capella
 ENV EASE_LOG_LOCATION=/proc/1/fd/1

--- a/remote/Dockerfile
+++ b/remote/Dockerfile
@@ -30,7 +30,7 @@ COPY wallpaper.png /tmp/wallpaper.png
 COPY bg-saved.cfg /home/techuser/.config/nitrogen/bg-saved.cfg
 
 # Copy Supervisor Configuration
-RUN pip install supervisor
+RUN pip install --break-system-packages supervisor
 COPY supervisord.conf /etc/supervisord.conf
 
 # Allow any user to start the RDP Server
@@ -49,7 +49,7 @@ COPY startup.sh .startup.sh
 RUN chmod 755 .startup.sh /home/techuser/.config/openbox/autostart
 
 # Prepare idletime metric endpoint
-RUN pip install prometheus-client
+RUN pip install --break-system-packages prometheus-client
 
 COPY metrics.py .metrics.py
 RUN chown techuser /home/techuser/.metrics.py

--- a/tests/local-git-server/Dockerfile
+++ b/tests/local-git-server/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-ARG BASE_IMAGE=debian:bullseye
+ARG BASE_IMAGE=debian:bookworm
 FROM $BASE_IMAGE
 
 EXPOSE 80


### PR DESCRIPTION
New `pip` versions do not like to install in "system" folders. However, this always worked for us, so we can keep doing it IMHO. Pip also does not like a `pip install --user` on Book worm.

The alternative is to set up venvs, but I think that's not needed for a (contained) docker image.

