### PR TITLE
fix: Load multiple models with the same project name

### DIFF
--- a/ease/Dockerfile
+++ b/ease/Dockerfile
@@ -110,7 +110,7 @@ WORKDIR /home/techuser
 
 COPY git_askpass.py /etc/git_askpass.py
 ENV GIT_ASKPASS=/etc/git_askpass.py
-RUN chmod +x /etc/git_askpass.py
+RUN chmod +rx /etc/git_askpass.py
 
 COPY startup.sh /opt/startup.sh
 RUN chmod +x /opt/startup.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 dynamic = ["version"]
 
 name = "capella-dockerimages-tests"
-requires-python = ">=3.9, <3.12"
+requires-python = ">=3.11, <3.12"
 license = { text = "Apache-2.0" }
 authors = [{ name = "DB Netz AG" }]
 dependencies = ["docker>=6.1.0", "pytest", "capellambse[decl]", "chardet"]
@@ -19,7 +19,7 @@ dev = ["black", "isort", "mypy", "pylint"]
 
 [tool.black]
 line-length = 79
-target-version = ["py39"]
+target-version = ["py311"]
 
 [tool.isort]
 profile = 'black'
@@ -31,7 +31,7 @@ no_implicit_optional = true
 show_error_codes = true
 warn_redundant_casts = true
 warn_unreachable = true
-python_version = "3.9"
+python_version = "3.11"
 
 [[tool.mypy.overrides]]
 # Untyped third party libraries

--- a/readonly/load_models.py
+++ b/readonly/load_models.py
@@ -11,20 +11,41 @@
     The acronym EASE stands for "Eclipse Advanced Scripting Environment".
     Further information: https://www.eclipse.org/ease/
 """
+import enum
 import json
 import logging
 import os
 import pathlib
+import re
+import string
 import subprocess
 import tempfile
 import typing as t
 
 from eclipse.system.resources import importProject
-from lxml import etree as ET
+from lxml import etree
 from lxml.builder import E
 
 logging.basicConfig(level="DEBUG")
 log = logging.getLogger(__file__)
+
+
+class _ProjectNature(enum.Enum):
+    library = "org.polarsys.capella.library.nature"
+    project = "org.polarsys.capella.project.nature"
+
+
+class _ProjectDict(t.TypedDict):
+    name: t.NotRequired[str]
+    url: str
+    revision: str
+    depth: int
+    entrypoint: str | pathlib.Path
+    username: str | None
+    password: str | None
+    nature: t.NotRequired[_ProjectNature | str]
+    location: t.NotRequired[pathlib.Path]
+    etree: t.NotRequired[etree.ElementTree]
 
 
 def disable_welcome_screen() -> None:
@@ -33,12 +54,12 @@ def disable_welcome_screen() -> None:
         "/workspace/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.ui.prefs"
     )
     prefs_path.parent.mkdir(parents=True, exist_ok=True)
-    prefs_path.write_text(prefs)
+    prefs_path.write_text(prefs, encoding="utf-8")
     log.info("Disabled Welcome screen")
 
 
-def fetch_projects_from_environment() -> list[dict[str, str]]:
-    projects = []
+def fetch_projects_from_environment() -> list[_ProjectDict]:
+    projects: list[_ProjectDict] = []
 
     git_repo_url = os.getenv("GIT_URL")
     git_repo_revision = os.getenv("GIT_REVISION")
@@ -48,8 +69,8 @@ def fetch_projects_from_environment() -> list[dict[str, str]]:
             {
                 "url": git_repo_url,
                 "revision": git_repo_revision,
-                "depth": os.getenv("GIT_DEPTH"),
-                "entrypoint": os.getenv("GIT_ENTRYPOINT"),
+                "depth": int(os.getenv("GIT_DEPTH", "0")),
+                "entrypoint": os.environ["GIT_ENTRYPOINT"],
                 "username": os.getenv("GIT_USERNAME", None),
                 "password": os.getenv("GIT_PASSWORD", None),
             }
@@ -58,7 +79,7 @@ def fetch_projects_from_environment() -> list[dict[str, str]]:
     return projects + json.loads(os.getenv("GIT_REPOS_JSON", "[]"))
 
 
-def clone_git_model(project: dict[str, str]) -> None:
+def clone_git_model(project: _ProjectDict) -> None:
     log.info("Cloning git repository with url %s", project["url"])
 
     project["location"] = pathlib.Path(tempfile.mkdtemp(prefix="model_"))
@@ -68,7 +89,7 @@ def clone_git_model(project: dict[str, str]) -> None:
     if revision := project["revision"]:
         flags += ["--single-branch", "--branch", revision]
 
-    git_depth = int(project.get("depth", 0))
+    git_depth = project["depth"]
     if git_depth != 0:
         flags += ["--depth", str(git_depth)]
 
@@ -86,59 +107,133 @@ def clone_git_model(project: dict[str, str]) -> None:
     )
 
 
-def resolve_entrypoint(project: dict[str, str]) -> None:
+def resolve_entrypoint(project: _ProjectDict) -> None:
     if entrypoint := project["entrypoint"]:
-        project["location"] = pathlib.Path(
+        project["entrypoint"] = pathlib.Path(
             project["location"],
-            str(pathlib.Path(entrypoint).parent).lstrip("/"),
+            str(pathlib.Path(entrypoint)).lstrip("/"),
         )
 
+        assert isinstance(project["entrypoint"], pathlib.Path)
+        project["location"] = project["entrypoint"].parent
 
-def generate_project_file(project: dict[str, str]) -> None:
+
+def derive_project_name_from_aird(project_location: pathlib.Path) -> str:
+    return next(project_location.glob("*.aird")).stem
+
+
+def load_or_generate_project_etree(project: _ProjectDict) -> None:
+    project_description_file: pathlib.Path = project["location"] / ".project"
+    if project_description_file.exists():
+        project["etree"] = etree.fromstring(
+            project_description_file.read_bytes()
+        )
+    else:
+        project["etree"] = generate_project_etree(project)
+
+
+def derive_project_name(project: _ProjectDict) -> None:
+    project["name"] = project["etree"].find("name").text.strip()
+
+
+def generate_project_etree(project: _ProjectDict) -> etree.ElementTree:
     # More information:
     # https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fmisc%2Fproject_description_file.html&cp%3D2_1_3_11
 
+    if project.get("nature", "") in _ProjectNature.__members__:
+        assert isinstance(project["nature"], str)
+        nature = _ProjectNature[project["nature"]]
+    else:
+        nature = _ProjectNature.project
+
+    return E.projectDescription(
+        E.name(derive_project_name_from_aird(project["location"])),
+        E.comment(),
+        E.projects(),
+        E.buildSpec(),
+        E.natures(E.nature(nature.value)),
+    )
+
+
+def write_updated_project_file(project: _ProjectDict) -> None:
     project_description_file: pathlib.Path = project["location"] / ".project"
-    if not project_description_file.exists():
-        name = next(project["location"].glob("*.aird")).stem
-        natures = {
-            "library": "org.polarsys.capella.library.nature",
-            "project": "org.polarsys.capella.project.nature",
-        }
-
-        if project.get("nature", "") in natures:
-            nature = natures[project["nature"]]
-        else:
-            nature = natures["project"]
-
-        xml = E.projectDescription(
-            E.name(name),
-            E.comment(),
-            E.projects(),
-            E.buildSpec(),
-            E.natures(E.nature(nature)),
-        )
-
-        project_description_file.write_bytes(ET.tostring(xml))
+    project_description_file.write_bytes(etree.tostring(project["etree"]))
 
 
-def import_project(project: dict[str, str]) -> None:
+def import_project(project: _ProjectDict) -> None:
     log.info("Loading project into workspace: %s", str(project["location"]))
     importProject(str(project["location"]))
     log.info("Loading of project was successful: %s", str(project["location"]))
 
 
-if __name__ == "__main__":
+def resolve_duplicate_names(projects: list[_ProjectDict]) -> None:
+    duplicated_projects_grouped = group_projects_by_name(projects)
+
+    for duplicated_projects in duplicated_projects_grouped:
+        for duplicated_project in duplicated_projects:
+            append_revision_to_project_name(duplicated_project)
+
+    # Check again for duplicated projects (same project name and same revision)
+    duplicated_projects_grouped = group_projects_by_name(projects)
+    for duplicated_projects in duplicated_projects_grouped:
+        for counter, duplicated_project in enumerate(duplicated_projects):
+            add_suffix_to_project_name(duplicated_project, str(counter))
+
+
+def group_projects_by_name(
+    projects: list[_ProjectDict],
+) -> list[list[_ProjectDict]]:
+    grouped_projects: dict[str, list[_ProjectDict]] = {}
+
+    for project in projects:
+        project_name = project["name"]
+        if project_name in grouped_projects:
+            grouped_projects[project_name].append(project)
+        else:
+            grouped_projects[project_name] = [project]
+
+    return [
+        projects_per_name
+        for projects_per_name in grouped_projects.values()
+        if len(projects_per_name) > 1
+    ]
+
+
+def add_suffix_to_project_name(project: _ProjectDict, suffix: str) -> None:
+    new_name = project["name"] + "-" + suffix
+    project["name"] = new_name
+
+    project["etree"].find("name").text = new_name
+
+
+def append_revision_to_project_name(project: _ProjectDict) -> None:
+    valid_chars = string.ascii_letters + string.digits + "._-"
+    sanitized_revision = re.sub(f"[^{valid_chars}]", "-", project["revision"])
+
+    add_suffix_to_project_name(project, sanitized_revision)
+
+
+def main():
     projects = fetch_projects_from_environment()
     print("---START_LOAD_MODEL---")
     try:
         for project in projects:
             clone_git_model(project)
             resolve_entrypoint(project)
-            generate_project_file(project)
+            load_or_generate_project_etree(project)
+            derive_project_name(project)
+
+        resolve_duplicate_names(projects)
+
+        for project in projects:
+            write_updated_project_file(project)
             import_project(project)
         print("---FINISH_LOAD_MODEL---")
     except Exception as e:
         print("---FAILURE_LOAD_MODEL---")
         raise e
     disable_welcome_screen()
+
+
+if __name__ == "__main__":
+    main()

--- a/readonly/startup.sh
+++ b/readonly/startup.sh
@@ -10,8 +10,7 @@ unset RMT_PASSWORD
 # Prepare Workspace
 echo "---START_PREPARE_WORKSPACE---"
 export DISPLAY=:99
-Xvfb :99 -screen 0 1920x1080x8 -nolisten tcp &
-/opt/capella/capella -clean -data /workspace --launcher.suppressErrors -nosplash -consolelog -application org.eclipse.ease.runScript -script "file:/opt/scripts/load_models.py";
+xvfb-run /opt/capella/capella -clean -data /workspace --launcher.suppressErrors -nosplash -consolelog -application org.eclipse.ease.runScript -script "file:/opt/scripts/load_models.py";
 if [[ "$?" == 0 ]]
 then
     echo "---FINISH_PREPARE_WORKSPACE---"
@@ -20,7 +19,6 @@ else
     exit 1;
 fi
 
-pkill Xvfb
 unset GIT_USERNAME GIT_PASSWORD GIT_ASKPASS GIT_REPOS_JSON
 
 echo "---START_SESSION---"


### PR DESCRIPTION
Resolves https://github.com/DSD-DBS/capella-dockerimages/issues/173

This json...

```json
[
  {
    "url": "https://github.com/DSD-DBS/coffee-machine",
    "revision": "main",
    "depth": 0,
    "entrypoint": "coffee-machine-demo.aird"
  },
  {
    "url": "https://github.com/DSD-DBS/coffee-machine",
    "revision": "main",
    "depth": 0,
    "entrypoint": "coffee-machine-demo.aird"
  },
  {
    "url": "https://github.com/DSD-DBS/coffee-machine",
    "revision": "diagram-cache-workflow",
    "depth": 0,
    "entrypoint": "coffee-machine-demo.aird"
  }
]
```

... produces this output: 
![image](https://github.com/DSD-DBS/capella-dockerimages/assets/23395732/62c8ec82-d445-4db9-8d43-1559c006262b)


In general: 
- If there we have duplicates, add the sanitised revision to the project name.
- If there are still duplicates, count the projects and add a number as suffix.
- If we have even more duplicates, they are ignored.