### PR TITLE
perf: Increase memory limit to 5.5GB for Eclipse based tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ capella/base: base
 	rm capella/.dockerignore
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
+papyrus/base: DOCKER_BUILD_FLAGS=--platform linux/amd64
 papyrus/base: base
 	docker build $(DOCKER_BUILD_FLAGS) \
 		-t $(DOCKER_PREFIX)$@:$$DOCKER_TAG \
@@ -212,6 +213,7 @@ capella/remote: capella/base
 	$(MAKE) PUSH_IMAGES=$(PUSH_IMAGES) IMAGENAME=$@ .push
 
 papyrus/remote: DOCKER_TAG=$(PAPYRUS_VERSION)-$(CAPELLA_DOCKERIMAGES_REVISION)
+papyrus/remote: DOCKER_BUILD_FLAGS=--platform linux/amd64
 papyrus/remote: papyrus/base
 	docker build $(DOCKER_BUILD_FLAGS) \
 		-t $(DOCKER_PREFIX)$@:$$DOCKER_TAG \

--- a/capella/Dockerfile
+++ b/capella/Dockerfile
@@ -107,8 +107,12 @@ COPY ./versions/${CAPELLA_VERSION}/dropins /opt/capella/dropins
 ARG CAPELLA_DROPINS=""
 COPY install_dropins.py /opt/install_dropins.py
 COPY ./versions/${CAPELLA_VERSION}/dropins.yml /opt/dropins.yml
-RUN echo '-Dorg.eclipse.equinox.p2.transport.ecf.retry=15' >> /opt/capella/capella.ini
-RUN echo '-Dorg.eclipse.ecf.provider.filetransfer.retrieve.readTimeout=10000' >> /opt/capella/capella.ini
+
+ARG MEMORY_LIMIT=5500m
+
+RUN echo '-Dorg.eclipse.equinox.p2.transport.ecf.retry=15' >> /opt/capella/capella.ini && \
+    echo '-Dorg.eclipse.ecf.provider.filetransfer.retrieve.readTimeout=10000' >> /opt/capella/capella.ini && \
+    sed -i "s/-Xmx[^ ]*/-Xmx$MEMORY_LIMIT/g" /opt/capella/capella.ini
 RUN pip install --break-system-packages PyYAML && python install_dropins.py
 
 COPY ./versions/${CAPELLA_VERSION}/patches /opt/patches
@@ -129,7 +133,6 @@ RUN mkdir -p /opt/capella/configuration/.settings; \
     chown -R techuser /opt/capella/configuration && \
     chown -R techuser /opt/capella/p2/org.eclipse.equinox.p2.engine/profileRegistry && \
     chown techuser /opt /opt/capella/capella.ini
-
 
 RUN echo '-Dosgi.configuration.area=file:/opt/capella/configuration' >> /opt/capella/capella.ini
 COPY setup_workspace.py /opt/setup/setup_welcome_screen.py

--- a/eclipse/Dockerfile
+++ b/eclipse/Dockerfile
@@ -32,13 +32,16 @@ WORKDIR /opt/
 RUN tar -xf eclipse.tar.gz && \
     rm -rf eclipse.tar.gz
 
+ARG MEMORY_LIMIT=5500m
+
 RUN mkdir /workspace; \
     # Disable Welcome Screen
     mkdir -p /workspace/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.ui.prefs; \
     # Set workspace permissions
     chown -R techuser /workspace && \
     chmod +x eclipse/eclipse && \
-    chown -R techuser /opt/eclipse
+    chown -R techuser /opt/eclipse && \
+    sed -i "s/-Xmx[^ ]*/-Xmx$MEMORY_LIMIT/g" /opt/eclipse/eclipse.ini
 
 USER techuser
 

--- a/papyrus/Dockerfile
+++ b/papyrus/Dockerfile
@@ -15,12 +15,15 @@ WORKDIR /opt/
 RUN tar -xf papyrus.tar.gz && \
     rm -rf papyrus.tar.gz
 
+ARG MEMORY_LIMIT=5500m
+
 RUN mkdir /workspace; \
     # Disable Welcome Screen
     mkdir -p /workspace/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.ui.prefs; \
     # Set workspace permissions
     chown -R techuser /workspace && \
-    chmod +x Papyrus/papyrus
+    chmod +x Papyrus/papyrus && \
+    sed -i "s/-Xmx[^ ]*/-Xmx$MEMORY_LIMIT/g" /opt/Papyrus/papyrus.ini
 
 COPY ./autostart /home/techuser/.config/openbox/autostart
 


### PR DESCRIPTION
We were using the default memory limit from the default eclipse.ini files. In large projects, the memory limit can be reached quickly.

Therefore, we're increasing it to 5500m per default and give the user an option to configure it via the `MEMORY_LIMIT` build argument.