### PR TITLE
feat(jupyter): Use global venv and update requirements from template

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && \
     locales \
     python3 \
     python3-pip \
+    python3-venv \
     git-lfs \
     unzip \
     zip && \

--- a/jupyter-notebook/Dockerfile
+++ b/jupyter-notebook/Dockerfile
@@ -16,11 +16,21 @@ RUN apt update && \
 
 COPY docker-entrypoint.sh /
 COPY requirements_template.txt /etc/skel
+RUN chmod +x /docker-entrypoint.sh
 
-RUN chmod +x /docker-entrypoint.sh && \
-    python3 -m pip install --break-system-packages jupyterlab capellambse && \
+USER techuser
+
+# Activate virtual environment
+RUN python -m venv /home/techuser/.venv
+
+ENV _OLD_VIRTUAL_PATH="$PATH"
+ENV VIRTUAL_ENV=/home/techuser/.venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN python3 -m pip install -r /etc/skel/requirements_template.txt jupyterlab  && \
     jupyter labextension disable "@jupyterlab/extensionmanager-extension" && \
-    jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
+    jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
+    mkdir /home/techuser/.jupyter && chown techuser /home/techuser/.jupyter
 
 COPY jupyter_lab_config.py /home/techuser/.jupyter/jupyter_lab_config.py
 
@@ -29,7 +39,6 @@ ENV NOTEBOOKS_DIR=/workspace/notebooks
 
 EXPOSE $JUPYTER_PORT
 
-USER techuser
 WORKDIR $HOME
 
 ENTRYPOINT "/docker-entrypoint.sh"

--- a/jupyter-notebook/docker-entrypoint.sh
+++ b/jupyter-notebook/docker-entrypoint.sh
@@ -1,14 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
 
 echo "---START_PREPARE_WORKSPACE---"
 
 mkdir -p "$NOTEBOOKS_DIR"
 
 test -f "$NOTEBOOKS_DIR/requirements.txt" || cp /etc/skel/requirements_template.txt "$NOTEBOOKS_DIR/requirements.txt"
-pip install --break-system-packages -r "$NOTEBOOKS_DIR/requirements.txt" 2>&1 | tee "$NOTEBOOKS_DIR/installlog.txt"
+pip install -U -r "$NOTEBOOKS_DIR/requirements.txt" -r /etc/skel/requirements_template.txt 2>&1 | tee "$NOTEBOOKS_DIR/installlog.txt"
 
 echo "---START_SESSION---"
 

--- a/jupyter-notebook/requirements_template.txt
+++ b/jupyter-notebook/requirements_template.txt
@@ -4,3 +4,4 @@
 
 # numpy
 # pandas
+capellambse


### PR DESCRIPTION
- Added a `run-jupyter-notebook` target to the Makefile
- Install dependencies from requirements_template per default
- Update depdendencies automatically during container startup
- Use a global venv instead of `--break-system-packages`
- Change ownership of pip packages from root to techuser

Resolves #178