### PR TITLE
feat(jupyter): Add support for capellambse-context-diagrams

### DIFF
--- a/jupyter-notebook/Dockerfile
+++ b/jupyter-notebook/Dockerfile
@@ -11,7 +11,9 @@ RUN apt update && \
     libgirepository1.0-dev \
     libcairo2-dev \
     gir1.2-pango-1.0 \
-    graphviz && \
+    graphviz \
+    nodejs \
+    npm && \
     rm -rf /var/lib/apt/lists/*
 
 COPY docker-entrypoint.sh /

--- a/jupyter-notebook/requirements_template.txt
+++ b/jupyter-notebook/requirements_template.txt
@@ -1,7 +1,8 @@
-# Use this file to define custom dependencis for your Jupyter workspace.
+# Use this file to define custom dependencies for your Jupyter workspace.
 # The format of the requirements file is described at
 #    https://pip.pypa.io/en/stable/reference/requirements-file-format/
 
 # numpy
 # pandas
-capellambse
+capellambse[cli,decl,png,httpfiles]
+capellambse-context-diagrams


### PR DESCRIPTION
This PR adds support for [capellambse-context-diagrams](https://github.com/DSD-DBS/capellambse-context-diagrams) in the Jupyter Docker image. 

While I tested the functionality, I found a bug: JupyterLab printed a malformed JSON instead of proper HTML, PNG or SVG. Thanks to the great py-capellambse team, they already have a fix for it available: https://github.com/DSD-DBS/py-capellambse/pull/316 

The fix should be merged before we make the context diagrams available / this PR can be merged.