### PR TITLE
feat: Add reusable Github action for the `diagram cache`

### DIFF
--- a/ci-templates/github/diagram-cache/action.yml
+++ b/ci-templates/github/diagram-cache/action.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-name: 'Collab Manager: Diagram Cache'
+name: 'Generate diagram cache'
 description: 'An action to create and push a capella diagram cache'
 
 inputs:
@@ -27,8 +27,6 @@ inputs:
     description: 'Whether to push the diagram cache changes or not'
     required: false
     default: "true"
-  commit_branch:
-    description: 'The base branch to which the diagram cache belongs'
 
 runs:
   using: "composite"
@@ -44,21 +42,21 @@ runs:
       shell: bash
       run: >-
         python -m capellambse.diagram_cache
-        --model ${{ inputs.entry_point }}
+        --model "${{ inputs.entry_point }}"
         --output ./diagram_cache
         --index
-        --docker ghcr.io/dsd-dbs/capella-dockerimages/capella/base:{VERSION}-${{ inputs.capella_docker_images_dropins }}-dropins-${{ inputs.capella_docker_images_revision }}
+        --docker "ghcr.io/dsd-dbs/capella-dockerimages/capella/base:{VERSION}-${{ inputs.capella_docker_images_dropins }}-dropins-${{ inputs.capella_docker_images_revision }}"
     - name: Push diagram cache to orphan branch
       shell: bash
       run: |
-        DERIVED_BRANCH_NAME="$(echo diagram-cache/${{ inputs.commit_branch }})"
-        git switch "$DERIVED_BRANCH_NAME" || git switch --orphan "$DERIVED_BRANCH_NAME"
-        git reset
+        DERIVED_BRANCH_NAME="diagram-cache/${{ github.ref_name }}"
+        SHORT_COMMIT_SHA=$(git rev-parse --short "${{ github.sha }}")
+        git switch --orphan "$DERIVED_BRANCH_NAME"
         git add diagram_cache
-        if git diff --cached --exit-code &> /dev/null || [[ "$PUSH_DIAGRAM_CACHE" == "false" ]]; then exit 0; fi
+        if [[ "${{ inputs.push_diagram_cache }}" == "false" ]]; then exit 0; fi
         git config --local user.email "github-actions[bot]@users.noreply.github.com"
         git config --local user.name "capellambse[bot]"
-        git commit -m "${{ inputs.commit_msg }}"
+        git commit -m "${{ inputs.commit_msg }} for $SHORT_COMMIT_SHA"
         git push -o ci.skip --set-upstream origin $DERIVED_BRANCH_NAME --force
     - name: Archive diagram cache in artifacts
       uses: actions/upload-artifact@v3

--- a/ci-templates/github/diagram-cache/action.yml
+++ b/ci-templates/github/diagram-cache/action.yml
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Collab Manager: Diagram Cache'
+description: 'An action to create and push a capella diagram cache'
+
+inputs:
+  commit_msg:
+    description: 'The commit message for updating the diagram cache'
+    required: false
+    default: "docs: Update diagram cache"
+  entry_point:
+    description: 'The entry point of the used model'
+  capellambse_revision:
+    description: 'The revision of the py-capellambse package to install'
+    required: false
+    default: master
+  capella_docker_images_revision:
+    description: 'The revision of capella-dockerimages to use'
+    required: false
+    default:  main
+  capella_docker_images_dropins:
+    description: 'Please have a look at https://dsd-dbs.github.io/capella-dockerimages/capella/introduction/#supported-dropins'
+    required: false
+    default: selected
+  push_diagram_cache:
+    description: 'Whether to push the diagram cache changes or not'
+    required: false
+    default: "true"
+  commit_branch:
+    description: 'The base branch to which the diagram cache belongs'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.11
+    - name: Install capellambse
+      shell: bash
+      run: pip install "capellambse[cli]@git+https://github.com/DSD-DBS/py-capellambse.git@${{ inputs.capellambse_revision }}"
+    - name: Generate diagram cache
+      shell: bash
+      run: >-
+        python -m capellambse.diagram_cache
+        --model ${{ inputs.entry_point }}
+        --output ./diagram_cache
+        --index
+        --docker ghcr.io/dsd-dbs/capella-dockerimages/capella/base:{VERSION}-${{ inputs.capella_docker_images_dropins }}-dropins-${{ inputs.capella_docker_images_revision }}
+    - name: Push diagram cache to orphan branch
+      shell: bash
+      run: |
+        DERIVED_BRANCH_NAME="$(echo diagram-cache/${{ inputs.commit_branch }})"
+        git switch "$DERIVED_BRANCH_NAME" || git switch --orphan "$DERIVED_BRANCH_NAME"
+        git reset
+        git add diagram_cache
+        if git diff --cached --exit-code &> /dev/null || [[ "$PUSH_DIAGRAM_CACHE" == "false" ]]; then exit 0; fi
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "capellambse[bot]"
+        git commit -m "${{ inputs.commit_msg }}"
+        git push -o ci.skip --set-upstream origin $DERIVED_BRANCH_NAME --force
+    - name: Archive diagram cache in artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: diagram_cache
+        path: diagram_cache

--- a/docs/docs/ci-templates/github/diagram-cache.md
+++ b/docs/docs/ci-templates/github/diagram-cache.md
@@ -10,18 +10,20 @@ Please add the following section to your `.github/workflows/diagram-cache.yml`:
 ```yaml
 name: update_capella_diagram_cache
 
+on: push
+
 jobs:
   update_capella_diagram_cache:
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout code
-          uses: actions/checkout@v3
-        - name: Generate and upload diagram cache
-          uses: DSD-DBS/capella-dockerimages/ci-templates/github/diagram-cache@main
-          with:
-            entry_point: "test/test.aird" # Relative entrypoint to .aird file inside repository (starting from the root of the repository).
-            commit_branch: ${{ github.ref_name }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Generate and upload diagram cache
+        uses: DSD-DBS/capella-dockerimages/ci-templates/github/diagram-cache@main
+        with:
+          entry_point: test/test.aird # Relative entrypoint to .aird file inside repository (starting from the root of the repository).
 ```
-This is the minimal configuration, specifying only `entry_point` and `commit_branch` Nevertheless, there
+
+This is the minimal configuration, specifying only the `entry_point`. Nevertheless, there
 are several other options to configure your diagram cache workflow.
 For more options please have a look at the possible [inputs](https://github.com/DSD-DBS/capella-dockerimages/blob/main/ci-templates/github/diagram-cache.yml)

--- a/docs/docs/ci-templates/github/diagram-cache.md
+++ b/docs/docs/ci-templates/github/diagram-cache.md
@@ -1,0 +1,27 @@
+<!--
+ ~ SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+ ~ SPDX-License-Identifier: Apache-2.0
+ -->
+
+# Diagram cache
+
+Please add the following section to your `.github/workflows/diagram-cache.yml`:
+
+```yaml
+name: update_capella_diagram_cache
+
+jobs:
+  update_capella_diagram_cache:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v3
+        - name: Generate and upload diagram cache
+          uses: DSD-DBS/capella-dockerimages/ci-templates/github/diagram-cache@main
+          with:
+            entry_point: "test/test.aird" # Relative entrypoint to .aird file inside repository (starting from the root of the repository).
+            commit_branch: ${{ github.ref_name }}
+```
+This is the minimal configuration, specifying only `entry_point` and `commit_branch` Nevertheless, there
+are several other options to configure your diagram cache workflow.
+For more options please have a look at the possible [inputs](https://github.com/DSD-DBS/capella-dockerimages/blob/main/ci-templates/github/diagram-cache.yml)

--- a/docs/docs/ci-templates/index.md
+++ b/docs/docs/ci-templates/index.md
@@ -17,6 +17,6 @@ Currently, we provide the following Gitlab CI/CD templates:
 And the following Github CI/CD actions:
 
 - [Diagram cache](./github/diagram-cache.md): Export diagrams of a Capella model and store them in Github artifacts,
-with the option to push it to a new branch
+  with the option to push it to a new branch
 
 We offer more templates as part of our `py-capellambse` project. Please have a look [here](https://github.com/DSD-DBS/py-capellambse/tree/master/ci-templates/gitlab).

--- a/docs/docs/ci-templates/index.md
+++ b/docs/docs/ci-templates/index.md
@@ -14,4 +14,9 @@ Currently, we provide the following Gitlab CI/CD templates:
 - [Image builder](#image-builder): Build and push all Docker images to any Docker registry.
 - [Model validation](#model-validation): Runs the Capella model validation CLI tool.
 
+And the following Github CI/CD actions:
+
+- [Diagram cache](./github/diagram-cache.md): Export diagrams of a Capella model and store them in Github artifacts,
+with the option to push it to a new branch
+
 We offer more templates as part of our `py-capellambse` project. Please have a look [here](https://github.com/DSD-DBS/py-capellambse/tree/master/ci-templates/gitlab).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -22,6 +22,8 @@ nav:
           - Model validation: ci-templates/gitlab/model-validation.md
           - T4C export: ci-templates/gitlab/t4c-export.md
           - Test container clean up: ci-templates/gitlab/cleanup.md
+      - Github:
+          - Diagram cache: ci-templates/github/diagram-cache.md
   - Jupyter Notebooks: jupyter/index.md
   - Capella:
       - Introduction: capella/introduction.md


### PR DESCRIPTION
See first working usage here: https://github.com/DSD-DBS/coffee-machine/pull/8