### PR TITLE
refactor!: Rename `HOST` to `CSP_ORIGIN_HOST`

### DIFF
--- a/jupyter-notebook/jupyter_lab_config.py
+++ b/jupyter-notebook/jupyter_lab_config.py
@@ -1066,12 +1066,14 @@ c = get_config()  # noqa
 
 ## Supply overrides for the tornado.web.Application that the Jupyter server uses.
 #  Default: {}
-host = os.getenv("HOST")
 
-if host:
+# Origin host for the content security policy.
+csp_origin_host = os.getenv("CSP_ORIGIN_HOST")
+
+if csp_origin_host:
     c.ServerApp.tornado_settings = {
         "headers": {
-            "Content-Security-Policy": f"frame-ancestors self {host}",
+            "Content-Security-Policy": f"frame-ancestors self {csp_origin_host}",
         }
     }
 


### PR DESCRIPTION
The `HOST` environment variable is often used to determine the current host, not the origin host.

Therefore, we're changing the variable to `CSP_ORIGIN_HOST`.

This is a breaking change, but we're not aware of any usage yet.