### PR TITLE
feat: Add jupyter-collaboration as extension

### DIFF
--- a/jupyter-notebook/Dockerfile
+++ b/jupyter-notebook/Dockerfile
@@ -29,7 +29,7 @@ ENV _OLD_VIRTUAL_PATH="$PATH"
 ENV VIRTUAL_ENV=/home/techuser/.venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN python3 -m pip install -r /etc/skel/requirements_template.txt jupyterlab  && \
+RUN python3 -m pip install -r /etc/skel/requirements_template.txt jupyterlab jupyter-collaboration && \
     jupyter labextension disable "@jupyterlab/extensionmanager-extension" && \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     mkdir /home/techuser/.jupyter && chown techuser /home/techuser/.jupyter


### PR DESCRIPTION
The Jupyter Collaboration extensions allows real-time collaboration across multiple sessions.

To start a shared session, click the "Share" button on the top right of the session and include the token in the link.


https://github.com/DSD-DBS/capella-dockerimages/assets/23395732/cd617216-362a-486e-9068-18f9077c91e2



Be careful: All users with the link can now access the whole session until session termination!

Related to https://github.com/DSD-DBS/capella-collab-manager/issues/678