### PR TITLE
fix: Move xauth and dbus-x11 installation to capella/base

### DIFF
--- a/capella/Dockerfile
+++ b/capella/Dockerfile
@@ -75,7 +75,9 @@ RUN apt-get update && \
     apt-get install -y \
     libxtst6 \
     xdg-utils \
-    xvfb && \
+    xvfb \
+    xauth \
+    dbus-x11 && \
     rm -rf /var/lib/apt/lists/*;
 
 RUN if [ -s capella.zip ]; then \

--- a/ease/Dockerfile
+++ b/ease/Dockerfile
@@ -12,14 +12,8 @@ ENV SHELL=/bin/bash
 # Somehow OpenJDK does not install in one shot due to a (cyclic?) dependency on
 # package ca-certificates-java. Performing the install again fixes it.
 RUN apt-get update && \
-    apt-get install -y \
-    xdg-utils \
-    xvfb \
-    xauth \
-    dbus-x11 \
-    git-lfs && \
     # https://forums.debian.net/viewtopic.php?t=151997
-    ( apt-get install -y openjdk-17-jre || apt-get install -y openjdk-17-jre ) && \
+    apt-get install -y openjdk-17-jre || apt-get install -y openjdk-17-jre && \
     rm -rf /var/lib/apt/lists/*
 
 ARG GIT_EMAIL=contact@example.com


### PR DESCRIPTION
`capella/base` is also used to run Capella with `xvfb-run`. Therefore, we have to install xauth in the Capella base image.

The installation in the ease image is no longer necessary. It inherits the installation from the capella/base image.