### PR TITLE
fix(jupyter): Handle SIGTERM properly

### DIFF
--- a/jupyter-notebook/docker-entrypoint.sh
+++ b/jupyter-notebook/docker-entrypoint.sh
@@ -14,7 +14,7 @@ pip install -U -r "$NOTEBOOKS_DIR/requirements.txt" -r /etc/skel/requirements_te
 
 echo "---START_SESSION---"
 
-jupyter-lab --ip=0.0.0.0 \
+exec jupyter-lab --ip=0.0.0.0 \
     --port=$JUPYTER_PORT \
     --no-browser \
     --ServerApp.authenticate_prometheus=False \


### PR DESCRIPTION
SIGTERM was not passed to the Jupyter process.
The Jupyter container has completely ignored the SIGTERM signal and could only be stopped by sending a SIGKILL signal.

With Docker, the container is killed after a grace period of 10 seconds per default. Kubernetes has a default grace period of 30 seconds.