### PR TITLE
feat: Add symlink from notebook workspace to `/shared`

### DIFF
--- a/jupyter-notebook/docker-entrypoint.sh
+++ b/jupyter-notebook/docker-entrypoint.sh
@@ -12,6 +12,9 @@ mkdir -p "$NOTEBOOKS_DIR"
 test -f "$NOTEBOOKS_DIR/requirements.txt" || cp /etc/skel/requirements_template.txt "$NOTEBOOKS_DIR/requirements.txt"
 pip install -U -r "$NOTEBOOKS_DIR/requirements.txt" -r /etc/skel/requirements_template.txt 2>&1 | tee "$NOTEBOOKS_DIR/installlog.txt"
 
+mkdir -p "/shared"
+test -d "$NOTEBOOKS_DIR/shared" || ln -s /shared "$NOTEBOOKS_DIR/shared"
+
 echo "---START_SESSION---"
 
 jupyter-lab --ip=0.0.0.0 \


### PR DESCRIPTION
This feature is required for https://github.com/DSD-DBS/capella-collab-manager/pull/918. Shared volumes can be mounted to `/shared/<name>`, and a symlink is created from the notebooks workspace.