### PR TITLE
build: Add global venv for Python

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -36,9 +36,22 @@ ENV LC_ALL="en_GB.UTF-8"
 
 # Create techuser with UID
 ARG UID=1001
-RUN useradd -l -m -u $UID techuser
-RUN echo "techuser:tmp_passwd" | chpasswd
+RUN useradd -l -m -u $UID techuser && \
+    echo "techuser:tmp_passwd" | chpasswd \
+    && chown techuser /home/techuser
 ENV HOME=/home/techuser
-RUN chown techuser /home/techuser
 
-RUN ln -sf $(which python3) /usr/bin/python
+
+# This in analogous to the virtualenv activate script
+# To allow deactivation of the virtualenv, we need to save the old PATH
+ENV _OLD_VIRTUAL_PATH="$PATH"
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN ln -s $(which python3.11) /usr/bin/python && \
+    ln -sf $(which python3.11) /usr/bin/python3 && \
+    ln -sf $(which pip3.11) /usr/local/bin/pip && \
+    ln -sf $(which pip3.11) /usr/local/bin/pip3 && \
+    python -m venv /opt/.venv && \
+    chmod -R 777 /opt/.venv/bin/ && \
+    chmod -R 777 /opt/.venv/lib/python3.11/site-packages

--- a/capella/Dockerfile
+++ b/capella/Dockerfile
@@ -55,7 +55,7 @@ FROM base_new as build_online
 # https://github.com/moby/moby/issues/26533#issuecomment-246966836
 ONBUILD ARG CAPELLA_VERSION="5.2.0"
 ONBUILD COPY ./download_archive.py /opt/.download_archive.py
-ONBUILD RUN pip install --break-system-packages requests lxml && \
+ONBUILD RUN pip install requests lxml && \
     python .download_archive.py ${CAPELLA_VERSION};
 
 FROM base_new as build_offline
@@ -115,7 +115,7 @@ ARG MEMORY_LIMIT=5500m
 RUN echo '-Dorg.eclipse.equinox.p2.transport.ecf.retry=15' >> /opt/capella/capella.ini && \
     echo '-Dorg.eclipse.ecf.provider.filetransfer.retrieve.readTimeout=10000' >> /opt/capella/capella.ini && \
     sed -i "s/-Xmx[^ ]*/-Xmx$MEMORY_LIMIT/g" /opt/capella/capella.ini
-RUN pip install --break-system-packages PyYAML && python install_dropins.py
+RUN pip install PyYAML && python install_dropins.py
 
 COPY ./versions/${CAPELLA_VERSION}/patches /opt/patches
 RUN PATCH_DIR=/opt/patches /opt/patch.sh

--- a/ci-templates/gitlab/diagram-cache.yml
+++ b/ci-templates/gitlab/diagram-cache.yml
@@ -9,7 +9,7 @@ update_capella_diagram_cache:
     name: $DOCKER_REGISTRY/capella/base:${CAPELLA_DOCKER_IMAGES_TAG}
     entrypoint: [""]
   script:
-    - pip install --break-system-packages capellambse
+    - pip install capellambse
     - mkdir diagram_cache
     - |
       xvfb-run python <<EOF

--- a/ease/Dockerfile
+++ b/ease/Dockerfile
@@ -25,7 +25,7 @@ RUN git config --global user.name $GIT_USERNAME && \
 # Use Virtual Display
 ENV DISPLAY :99
 
-RUN pip install --break-system-packages py4j
+RUN pip install py4j
 
 # Offline build (fixed version)
 FROM prebuild as build_offline
@@ -88,7 +88,7 @@ USER root
 RUN rm -rf /tmp/extensions
 RUN echo "-Dorg.eclipse.swtbot.search.timeout=1000" >> /opt/capella/capella.ini
 
-RUN pip install --break-system-packages pyease
+RUN pip install pyease
 
 ENV EASE_WORKSPACE /workspace
 ENV EASE_SCRIPTS_LOCATION /opt/scripts

--- a/readonly/Dockerfile
+++ b/readonly/Dockerfile
@@ -9,7 +9,7 @@ ENV SHELL=/bin/bash
 
 USER root
 
-RUN pip install --break-system-packages lxml
+RUN pip install lxml
 COPY load_models.py /opt/scripts/load_models.py
 RUN chown -R techuser /opt/capella
 ENV EASE_LOG_LOCATION=/proc/1/fd/1

--- a/remote/Dockerfile
+++ b/remote/Dockerfile
@@ -30,7 +30,7 @@ COPY wallpaper.png /tmp/wallpaper.png
 COPY bg-saved.cfg /home/techuser/.config/nitrogen/bg-saved.cfg
 
 # Copy Supervisor Configuration
-RUN pip install --break-system-packages supervisor
+RUN pip install supervisor
 COPY supervisord.conf /etc/supervisord.conf
 
 # Allow any user to start the RDP server
@@ -50,7 +50,7 @@ COPY startup.sh .startup.sh
 RUN chmod 755 .startup.sh /home/techuser/.config/openbox/autostart
 
 # Prepare idletime metric endpoint
-RUN pip install --break-system-packages prometheus-client
+RUN pip install prometheus-client
 
 COPY metrics.py .metrics.py
 RUN chown techuser /home/techuser/.metrics.py


### PR DESCRIPTION
As a temporary solution, `--break-system-packages` was appended to all `pip install` commands in an earlier version.

This commit changes the behaviour to use a global venv. `--break-system-packages` is no longer needed on `pip install` commands.