### PR TITLE
Scan newly built images with Trivy

### DIFF
--- a/.github/actions/trivy/action.yml
+++ b/.github/actions/trivy/action.yml
@@ -27,6 +27,6 @@ runs:
     - name: Scan images
       run: |
         for image in ${{ inputs.images }}
-        do trivy -q image "${{ inputs.registry }}$image:${{ inputs.tag }}"
+        do trivy -q image --severity HIGH,CRITICAL "${{ inputs.registry }}$image:${{ inputs.tag }}"
         done
       shell: bash

--- a/.github/actions/trivy/action.yml
+++ b/.github/actions/trivy/action.yml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: CC0-1.0
+name: 'Scan images with Trivy'
+description: 'Scan images with Trivy'
+inputs:
+  registry:
+    description: 'Docker registry'
+    required: true
+  images:
+    description: 'Image names to scan'
+    required: true
+  tag:
+    description: 'Image tag'
+    required: true
+  trivy-version:
+    description: 'Trivy version to use'
+    required: false
+    default: '0.44.1'
+runs:
+  using: composite
+  steps:
+    - name: Install Trivy
+      run: |
+        curl -OLs https://github.com/aquasecurity/trivy/releases/download/v${{ inputs.trivy-version }}/trivy_${{ inputs.trivy-version }}_Linux-64bit.deb
+        sudo dpkg -i trivy_${{ inputs.trivy-version }}_Linux-64bit.deb
+      shell: bash
+    - name: Scan images
+      run: |
+        for image in ${{ inputs.images }}
+        do trivy -q image "${{ inputs.registry }}$image:${{ inputs.tag }}"
+        done
+      shell: bash

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -47,6 +47,7 @@ jobs:
         run: |
           echo "branch=$(git rev-parse --abbrev-ref HEAD | sed 's/[^a-zA-Z0-9]/-/g')" >> "$GITHUB_OUTPUT"
           echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "tag=${{ matrix.capella_version }}-${{ matrix.dropins.name }}-dropins-${{ steps.tag.outputs.branch }}" >> "$GITHUB_OUTPUT"
       - name: Build
         run: >
           make ${{ env.images }}
@@ -54,7 +55,7 @@ jobs:
           DOCKER_PREFIX="${{ env.registry }}"
           CAPELLA_DOCKERIMAGES_REVISION="${{ steps.tag.outputs.branch }}"
           CAPELLA_DROPINS="${{ matrix.dropins.dropins }}"
-          DOCKER_TAG_SCHEMA=${{ matrix.capella_version }}-${{ matrix.dropins.name }}-dropins-${{ steps.tag.outputs.branch }}
+          DOCKER_TAG_SCHEMA="${{ steps.tag.outputs.tag }}"
           DOCKER_BUILD_FLAGS="--label git-short-sha=${{ steps.tag.outputs.sha }}"
       - name: Install test dependencies
         run: |
@@ -63,12 +64,12 @@ jobs:
       - name: Run pytest
         run: >
           DOCKER_PREFIX="${{ env.registry }}"
-          DOCKER_TAG="${{ matrix.capella_version }}-${{ matrix.dropins.name }}-dropins-${{ steps.tag.outputs.branch }}"
+          DOCKER_TAG="${{ steps.tag.outputs.tag }}"
           CAPELLA_VERSION="${{ matrix.capella_version }}"
           LOCAL_GIT_TAG="latest"
           pytest -m "not (t4c_server or t4c)" tests
       - name: Push
         run: |
           for image in ${{ env.images }}
-          do docker push "${{ env.registry }}$image:${{ matrix.capella_version }}-${{ matrix.dropins.name }}-dropins-${{ steps.tag.outputs.branch }}"
+          do docker push "${{ env.registry }}$image:${{ steps.tag.outputs.tag }}"
           done

--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -68,6 +68,12 @@ jobs:
           CAPELLA_VERSION="${{ matrix.capella_version }}"
           LOCAL_GIT_TAG="latest"
           pytest -m "not (t4c_server or t4c)" tests
+      - name: Security scan
+        uses: ./.github/actions/trivy
+        with:
+          registry: ${{ env.registry }}
+          images: ${{ env.images }}
+          tag: ${{ steps.tag.outputs.tag }}
       - name: Push
         run: |
           for image in ${{ env.images }}


### PR DESCRIPTION
Added Trivy as a post-build step (before push).

I considered using the [trivy-action](https://github.com/aquasecurity/trivy-action) provided by Aqua Security, but that one doesn't deal with multiple images.

The output of Trivy is written in the logs. Not sure if we need to do anything else with it at the moment.


See #150 