### PR TITLE
fix: Remove --break-system-packages when installing capellambse

### DIFF
--- a/ci-templates/gitlab/diagram-cache.yml
+++ b/ci-templates/gitlab/diagram-cache.yml
@@ -9,7 +9,7 @@ update_capella_diagram_cache:
     name: $DOCKER_REGISTRY/capella/base:${CAPELLA_DOCKER_IMAGES_TAG}
     entrypoint: [""]
   script:
-    - pip install --break-system-packages capellambse
+    - pip install capellambse
     - mkdir diagram_cache
     - |
       xvfb-run python <<EOF


### PR DESCRIPTION
In the current base image the default pip installation seems to be too old to understand that flag and since there is a global venv it should not be needed anymore.