### PR TITLE
feat: install `neovim` in base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && \
     python3-venv \
     git-lfs \
     unzip \
+    neovim \
     zip && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The installation of Neovim introduces also a `vim` command launching Neovim.