### PR TITLE
feat: Change password by directly writing to `/etc/shadow`

### DIFF
--- a/readonly/startup.sh
+++ b/readonly/startup.sh
@@ -3,9 +3,10 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-set -ex
+set -exuo pipefail
+
 line=$(grep techuser /etc/shadow);
-echo ${line%%:*}:$(openssl passwd -6 -salt $(openssl rand -base64 16) $RMT_PASSWORD):${line#*:*:} > /etc/shadow;
+echo ${line%%:*}:$(openssl passwd -6 -salt $(openssl rand -base64 16) "${RMT_PASSWORD:?}"):${line#*:*:} > /etc/shadow;
 unset RMT_PASSWORD
 
 # Prepare Workspace

--- a/readonly/startup.sh
+++ b/readonly/startup.sh
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -ex
-echo -e "tmp_passwd\n$RMT_PASSWORD\n$RMT_PASSWORD" | passwd
+line=$(grep techuser /etc/shadow);
+echo ${line%%:*}:$(openssl passwd -6 -salt $(openssl rand -base64 16) $RMT_PASSWORD):${line#*:*:} > /etc/shadow;
 unset RMT_PASSWORD
 
 # Prepare Workspace

--- a/remote/Dockerfile
+++ b/remote/Dockerfile
@@ -36,8 +36,8 @@ COPY supervisord.conf /etc/supervisord.conf
 # Allow any user to start the RDP server
 # Depending on the base image used, Xwrapper.config may (not) be available and has to be created.
 RUN sed -i 's/allowed_users=console/allowed_users=anybody/g' /etc/X11/Xwrapper.config \
-    || echo "allowed_users=anybody" > /etc/X11/Xwrapper.config
-RUN id techuser || useradd -l -m -u 1001000000 techuser && echo "techuser:tmp_passwd" | chpasswd
+    || echo "allowed_users=anybody" > /etc/X11/Xwrapper.config && \
+    chmod 666 /etc/shadow
 
 # Set permissions
 RUN mkdir -p /run/xrdp/sockdir && \

--- a/remote/startup.sh
+++ b/remote/startup.sh
@@ -3,11 +3,12 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+set -exuo pipefail
+
 if [ "$(whoami)" == "root" ] || [ "$(whoami)" == "techuser" ];
 then
     line=$(grep techuser /etc/shadow);
-    echo ${line%%:*}:$(openssl passwd -6 -salt $(openssl rand -base64 16) $RMT_PASSWORD):${line#*:*:} > /etc/shadow;
+    echo ${line%%:*}:$(openssl passwd -6 -salt $(openssl rand -base64 16) "${RMT_PASSWORD:?}"):${line#*:*:} > /etc/shadow;
 else
     echo "Only techuser and root are supported as users.";
     exit 1;

--- a/remote/startup.sh
+++ b/remote/startup.sh
@@ -4,16 +4,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -e
-if [ "$(whoami)" == "root" ];
+if [ "$(whoami)" == "root" ] || [ "$(whoami)" == "techuser" ];
 then
-    echo -e "$RMT_PASSWORD\n$RMT_PASSWORD" | passwd techuser;
-elif [ "$(whoami)" == "techuser" ];
-then
-    echo -e "tmp_passwd\n$RMT_PASSWORD\n$RMT_PASSWORD" | passwd;
+    line=$(grep techuser /etc/shadow);
+    echo ${line%%:*}:$(openssl passwd -6 -salt $(openssl rand -base64 16) $RMT_PASSWORD):${line#*:*:} > /etc/shadow;
 else
     echo "Only techuser and root are supported as users.";
     exit 1;
 fi
+
+unset RMT_PASSWORD
 
 # Run preparation scripts
 for filename in /opt/setup/*.py; do

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,8 +14,8 @@ import re
 import shutil
 import subprocess
 import tarfile
+import textwrap
 import time
-import typing as t
 
 import chardet
 import docker
@@ -449,57 +449,72 @@ def copy_test_project_into_git_repo(git_path: pathlib.Path):
 
 
 def commit_and_push_git_repo(path: pathlib.Path):
-    subprocess.run(  # pylint: disable=subprocess-run-check
-        ["git", "config", "user.email", GIT_EMAIL],
-        cwd=path,
-        check=True,
-        text=True,
-        capture_output=True,
-    )
+    try:
+        subprocess.run(  # pylint: disable=subprocess-run-check
+            ["git", "config", "user.email", GIT_EMAIL],
+            cwd=path,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
 
-    subprocess.run(  # pylint: disable=subprocess-run-check
-        ["git", "config", "user.name", GIT_USERNAME],
-        cwd=path,
-        check=True,
-        text=True,
-        capture_output=True,
-    )
+        subprocess.run(  # pylint: disable=subprocess-run-check
+            ["git", "config", "user.name", GIT_USERNAME],
+            cwd=path,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
 
-    subprocess.run(  # pylint: disable=subprocess-run-check
-        ["git", "add", "."],
-        cwd=path,
-        check=True,
-        text=True,
-        capture_output=True,
-    )
+        subprocess.run(  # pylint: disable=subprocess-run-check
+            ["git", "add", "."],
+            cwd=path,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
 
-    subprocess.run(  # pylint: disable=subprocess-run-check
-        [
-            "git",
-            "-c",
-            "commit.gpgsign=false",
-            "commit",
-            "--message",
-            "test: Exporter test",
-        ],
-        cwd=path,
-        check=True,
-        text=True,
-        capture_output=True,
-    )
+        subprocess.run(  # pylint: disable=subprocess-run-check
+            [
+                "git",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "--message",
+                "test: Exporter test",
+            ],
+            cwd=path,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
 
-    subprocess.run(  # pylint: disable=subprocess-run-check
-        ["git", "push", "origin", GIT_REPO_BRANCH],
-        env={
-            "GIT_USERNAME": GIT_USERNAME,
-            "GIT_PASSWORD": GIT_PASSWORD,
-            "GIT_ASKPASS": "/etc/git_askpass.py",
-        },
-        cwd=path,
-        check=True,
-        text=True,
-        capture_output=True,
-    )
+        subprocess.run(  # pylint: disable=subprocess-run-check
+            ["git", "push", "origin", GIT_REPO_BRANCH],
+            env={
+                "GIT_USERNAME": GIT_USERNAME,
+                "GIT_PASSWORD": GIT_PASSWORD,
+                "GIT_ASKPASS": "/etc/git_askpass.py",
+            },
+            cwd=path,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
+    except subprocess.CalledProcessError as err:
+        logging.error(
+            "Git command failed. See stacktrace below.\n%s\n%s",
+            textwrap.indent(
+                err.stdout,
+                "[STDOUT] ",
+            ),
+            textwrap.indent(
+                err.stderr,
+                "[STDERR] ",
+            ),
+        )
+        raise err
 
 
 def _get_basic_auth() -> auth.HTTPBasicAuth:

--- a/tests/local-git-server/Dockerfile
+++ b/tests/local-git-server/Dockerfile
@@ -1,10 +1,12 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-ARG BASE_IMAGE=debian:bookworm
+ARG BASE_IMAGE=debian:bookworm-slim
 FROM $BASE_IMAGE
 
 EXPOSE 80
+
+USER root
 
 RUN apt-get update && \
     apt-get upgrade --yes && \
@@ -15,7 +17,9 @@ RUN apt-get update && \
 
 COPY lighttpd.conf /etc/lighttpd/lighttpd.conf
 
-RUN mkdir -p /var/www/git/git-test-repo.git
+RUN mkdir -p /var/www/git/git-test-repo.git && chown -R 1001 /var/www/git
+
+USER 1001
 
 WORKDIR /var/www/git/git-test-repo.git
 RUN git init -b main --bare && \


### PR DESCRIPTION
The use of `passwd` is not possible in restricted environments. It produces `Authentication token manipulation error`.

In one of our environments, session creation stopped after an OpenShift cluster update to version 4.11.
Our suspect is the change of the Pod security admission. More information can be found in the release notes: https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html#ocp-4-11-auth-pod-security-admission