### PR TITLE
fix: Fix model validation

### DIFF
--- a/ci-templates/gitlab/model-validation.yml
+++ b/ci-templates/gitlab/model-validation.yml
@@ -6,6 +6,8 @@ model-validation:
     name: $DOCKER_REGISTRY/capella/base:${CAPELLA_DOCKER_IMAGES_TAG}
     entrypoint: [""]
   script:
+    # As our containers run with techuser (non-root) git commands fail with dubious ownership, see <https://gitlab.com/gitlab-org/gitlab-runner/-/issues/29022> for the solution.
+    - git config --global --add safe.directory ${CI_PROJECT_DIR}
     - git fetch
     - if [ ! -z $CI_COMMIT_BRANCH ]; then git reset --hard origin/$CI_COMMIT_BRANCH; fi
     - BUILD_DIR=$(pwd)


### PR DESCRIPTION
We run containers with techuser (non-root) but the environment is owned by root. This causes any git command to fail. This commit fixes the problem by adding `safe.directory` to the global git config.