### PR TITLE
feat!: Configurable workspace directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ run-jupyter-notebook: jupyter-notebook
 	docker run $(DOCKER_RUN_FLAGS) \
 		-p $(WEB_PORT):8888 \
 		-v $$(pwd)/volumes/workspace/notebooks:/tmp/notebooks \
-		-e NOTEBOOKS_DIR=/tmp/notebooks \
+		-e WORKSPACE_DIR=/tmp/notebooks \
 		-e JUPYTER_BASE_URL=/ \
 		$(DOCKER_PREFIX)$<:$(JUPYTER_NOTEBOOK_REVISION)
 

--- a/capella/autostart
+++ b/capella/autostart
@@ -13,8 +13,8 @@ then
     if [ "$RESTART_CAPELLA" = "1" ];
     then
         # Run capella in a loop:
-        ( while true; do /opt/capella/capella -data /workspace > /var/log/capella.stdout.log 2> /var/log/capella.stderr.log; sleep 1; done ) &
+        ( while true; do /opt/capella/capella -data ${WORKSPACE_DIR:-/workspace} > /var/log/capella.stdout.log 2> /var/log/capella.stderr.log; sleep 1; done ) &
     else
-        /opt/capella/capella -data /workspace > /var/log/capella.stdout.log 2> /var/log/capella.stderr.log &
+        /opt/capella/capella -data ${WORKSPACE_DIR:-/workspace} > /var/log/capella.stdout.log 2> /var/log/capella.stderr.log &
     fi
 fi

--- a/capella/setup_workspace.py
+++ b/capella/setup_workspace.py
@@ -4,14 +4,16 @@
 from __future__ import annotations
 
 import logging
+import os
 import pathlib
 import re
 
 logging.basicConfig(level=logging.DEBUG)
 LOGGER = logging.getLogger("Capella preparation")
 
+WORKSPACE_DIR = os.getenv("WORKSPACE_DIR", "/workspace")
 ECLIPSE_SETTINGS_BASE_PATH = pathlib.Path(
-    "/workspace/.metadata/.plugins/org.eclipse.core.runtime/.settings"
+    f"{WORKSPACE_DIR}/.metadata/.plugins/org.eclipse.core.runtime/.settings"
 )
 
 
@@ -71,7 +73,7 @@ if __name__ == "__main__":
     replace_config(
         ECLIPSE_SETTINGS_BASE_PATH / "org.eclipse.egit.core.prefs",
         "core_defaultRepositoryDir",
-        "/workspace/git",
+        f"{WORKSPACE_DIR}/git",
     )
 
     set_git_merge_mode()

--- a/docs/docs/base.md
+++ b/docs/docs/base.md
@@ -25,6 +25,7 @@ custom registry URLs, your timezone, CA certificates and any other stuff.
 The following environment variable can be set in all images:
 
 - `WORKSPACE_DIR`: The directory applications (Eclipse, Capella, Jupyter) will use as workspace.
+  The workspace directory shall be a subdirectory of `/workspace` or `/home/techuser`.
 
 ## Use the prebuilt image
 

--- a/docs/docs/base.md
+++ b/docs/docs/base.md
@@ -22,6 +22,10 @@ deploy the containers in a K8s cluster and your company has some security restri
 Feel free to modify this image to your specific needs. You are able to set proxies,
 custom registry URLs, your timezone, CA certificates and any other stuff.
 
+The following environment variable can be set in all images:
+
+- `WORKSPACE_DIR`: The directory applications (Eclipse, Capella, Jupyter) will use as workspace.
+
 ## Use the prebuilt image
 
 ```

--- a/docs/docs/jupyter/index.md
+++ b/docs/docs/jupyter/index.md
@@ -19,13 +19,13 @@ docker build -t jupyter-notebook jupyter-notebook
 ## Run the `jupyter-notebook` image
 
 ```zsh
-docker run -ti --rm -e NOTEBOOKS_DIR=/tmp/notebooks -p 8888:8888 jupyter-notebook
+docker run -ti --rm -e WORKSPACE_DIR=/tmp/notebooks -p 8888:8888 jupyter-notebook
 ```
 
 The following environment variables can be defined:
 
 - `JUPYTER_PORT`: The port to run the jupyter server on.
-- `NOTEBOOKS_DIR`: The working directory for JupyterLab.
+- `WORKSPACE_DIR`: The working directory for JupyterLab.
 - `JUPYTER_BASE_URL`: A context path to access the jupyter server.
   This allows you to run multiple server containers on the same domain.
 - `JUPYTER_TOKEN`: A token for accessing the environment.

--- a/eclipse/autostart
+++ b/eclipse/autostart
@@ -11,8 +11,8 @@ then
     if [ "$RESTART_ECLIPSE" = "1" ];
     then
         # Restart Eclipse automatically
-        ( while true; do /opt/eclipse/eclipse -data /workspace > /var/log/eclipse.stdout.log 2> /var/log/eclipse.stderr.log; sleep 1; done ) &
+        ( while true; do /opt/eclipse/eclipse -data ${WORKSPACE_DIR:-/workspace} > /var/log/eclipse.stdout.log 2> /var/log/eclipse.stderr.log; sleep 1; done ) &
     else
-        /opt/eclipse/eclipse -data /workspace > /var/log/eclipse.stdout.log 2> /var/log/eclipse.stderr.log &
+        /opt/eclipse/eclipse -data ${WORKSPACE_DIR:-/workspace} > /var/log/eclipse.stdout.log 2> /var/log/eclipse.stderr.log &
     fi
 fi

--- a/jupyter-notebook/Dockerfile
+++ b/jupyter-notebook/Dockerfile
@@ -40,7 +40,7 @@ RUN python3 -m pip install --no-cache-dir -r /etc/skel/requirements_template.txt
 COPY jupyter_lab_config.py /home/techuser/.jupyter/jupyter_lab_config.py
 
 ENV JUPYTER_PORT=8888
-ENV NOTEBOOKS_DIR=/workspace/notebooks
+ENV WORKSPACE_DIR=/workspace/notebooks
 
 EXPOSE $JUPYTER_PORT
 

--- a/jupyter-notebook/docker-entrypoint.sh
+++ b/jupyter-notebook/docker-entrypoint.sh
@@ -15,12 +15,12 @@ set -euo pipefail
 
 echo "---START_PREPARE_WORKSPACE---"
 
-mkdir -p "$NOTEBOOKS_DIR"
+mkdir -p "$WORKSPACE_DIR"
 
-test -f "$NOTEBOOKS_DIR/requirements.txt" || cp /etc/skel/requirements_template.txt "$NOTEBOOKS_DIR/requirements.txt"
-pip install -U -r "$NOTEBOOKS_DIR/requirements.txt" -r /etc/skel/requirements_template.txt 2>&1 | tee "$NOTEBOOKS_DIR/installlog.txt"
+test -f "$WORKSPACE_DIR/requirements.txt" || cp /etc/skel/requirements_template.txt "$WORKSPACE_DIR/requirements.txt"
+pip install -U -r "$WORKSPACE_DIR/requirements.txt" -r /etc/skel/requirements_template.txt 2>&1 | tee "$WORKSPACE_DIR/installlog.txt"
 
-test -d "$NOTEBOOKS_DIR/shared" || ln -s /shared "$NOTEBOOKS_DIR/shared"
+test -d "$WORKSPACE_DIR/shared" || ln -s /shared "$WORKSPACE_DIR/shared"
 
 echo "---START_SESSION---"
 
@@ -29,4 +29,4 @@ exec jupyter-lab --ip=0.0.0.0 \
     --no-browser \
     --ServerApp.authenticate_prometheus=False \
     --ServerApp.base_url="$JUPYTER_BASE_URL" \
-    --ServerApp.root_dir="$NOTEBOOKS_DIR"
+    --ServerApp.root_dir="$WORKSPACE_DIR"

--- a/papyrus/autostart
+++ b/papyrus/autostart
@@ -11,8 +11,8 @@ then
     if [ "$RESTART_PAPYRUS" = "1" ];
     then
         # Restart Papyrus automatically
-        ( while true; do /opt/Papyrus/papyrus -data /workspace > /var/log/papyrus.stdout.log 2> /var/log/papyrus.stderr.log; sleep 1; done ) &
+        ( while true; do /opt/Papyrus/papyrus -data ${WORKSPACE_DIR:-/workspace} > /var/log/papyrus.stdout.log 2> /var/log/papyrus.stderr.log; sleep 1; done ) &
     else
-        /opt/Papyrus/papyrus -data /workspace > /var/log/papyrus.stdout.log 2> /var/log/papyrus.stderr.log &
+        /opt/Papyrus/papyrus -data ${WORKSPACE_DIR:-/workspace} > /var/log/papyrus.stdout.log 2> /var/log/papyrus.stderr.log &
     fi
 fi

--- a/readonly/load_models.py
+++ b/readonly/load_models.py
@@ -29,6 +29,8 @@ from lxml.builder import E
 logging.basicConfig(level="DEBUG")
 log = logging.getLogger(__file__)
 
+WORKSPACE_DIR = os.getenv("WORKSPACE_DIR", "/workspace")
+
 
 class _ProjectNature(enum.Enum):
     library = "org.polarsys.capella.library.nature"
@@ -51,7 +53,7 @@ class _ProjectDict(t.TypedDict):
 def disable_welcome_screen() -> None:
     prefs = "\n".join(["eclipse.preferences.version=1", "showIntro=false"])
     prefs_path = pathlib.Path(
-        "/workspace/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.ui.prefs"
+        f"{WORKSPACE_DIR}/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.ui.prefs"
     )
     prefs_path.parent.mkdir(parents=True, exist_ok=True)
     prefs_path.write_text(prefs, encoding="utf-8")

--- a/readonly/startup.sh
+++ b/readonly/startup.sh
@@ -14,7 +14,7 @@ unset RMT_PASSWORD
 # Prepare Workspace
 echo "---START_PREPARE_WORKSPACE---"
 export DISPLAY=:99
-xvfb-run /opt/capella/capella -clean -data /workspace --launcher.suppressErrors -nosplash -consolelog -application org.eclipse.ease.runScript -script "file:/opt/scripts/load_models.py";
+xvfb-run /opt/capella/capella -clean -data ${WORKSPACE_DIR:-/workspace} --launcher.suppressErrors -nosplash -consolelog -application org.eclipse.ease.runScript -script "file:/opt/scripts/load_models.py";
 if [[ "$?" == 0 ]]
 then
     echo "---FINISH_PREPARE_WORKSPACE---"

--- a/remote/autostart
+++ b/remote/autostart
@@ -13,8 +13,8 @@ then
     if [ "$RESTART_CAPELLA" = "1" ];
     then
         # Run capella in a loop:
-        ( while true; do /opt/capella/capella -data /workspace > /var/log/capella.stdout.log 2> /var/log/capella.stderr.log; sleep 1; done ) &
+        ( while true; do /opt/capella/capella -data ${WORKSPACE_DIR:-/workspace} > /var/log/capella.stdout.log 2> /var/log/capella.stderr.log; sleep 1; done ) &
     else
-        /opt/capella/capella -data /workspace > /var/log/capella.stdout.log 2> /var/log/capella.stderr.log &
+        /opt/capella/capella -data ${WORKSPACE_DIR:-/workspace} > /var/log/capella.stdout.log 2> /var/log/capella.stderr.log &
     fi
 fi

--- a/t4c/setup_workspace.py
+++ b/t4c/setup_workspace.py
@@ -13,8 +13,9 @@ from collections import Counter
 logging.basicConfig(level=logging.DEBUG)
 LOGGER = logging.getLogger("TeamForCapella preparation")
 
+WORKSPACE_DIR = os.getenv("WORKSPACE_DIR", "/workspace")
 OBEO_COLLAB_CONF = pathlib.Path(
-    "/workspace/.metadata",
+    "{WORKSPACE_DIR}/.metadata",
     ".plugins/org.eclipse.core.runtime/.settings/fr.obeo.dsl.viewpoint.collab.prefs",
 )
 REPOSITORIES_BASE_PATH = pathlib.Path("/opt/capella/configuration")


### PR DESCRIPTION
In order to support one shared persistent workspace for multiple simultanious (capella) sessions, we need to make sure every session is starting in its own workspace.

To make it consistent, Jupyters `NOTEBOOKS_DIR` has been renamed to `WORKSPACE_DIR`.

See https://github.com/DSD-DBS/capella-collab-manager/issues/1004.

This is a breaking change: The environment variable `NOTEBOOKS_DIR` was replaced with  `WORKSPACE_DIR`.