### PR TITLE
docs: Update deprecated markdown extensions

### DIFF
--- a/docs/docs/ci-templates/gitlab/release-train.md
+++ b/docs/docs/ci-templates/gitlab/release-train.md
@@ -25,7 +25,7 @@ For changes in your Gitlab image builder repository:
 
 You can customize the pipeline to your needs (e.g., define multiple environments). The template provides three different jobs `.base`, `.capella` and `.jupyter` which can be extended:
 
-```yml
+```yaml
 include:
   - remote: https://raw.githubusercontent.com/DSD-DBS/capella-dockerimages/${CAPELLA_DOCKER_IMAGES_REVISION}/ci-templates/gitlab/release-train.yml"
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -61,8 +61,8 @@ markdown_extensions:
   - pymdownx.snippets
   - attr_list
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span


### PR DESCRIPTION
In addition, rename `yml` to `yaml` as language in one code block to add syntax highlighting.