### PR TITLE
Improvements to global git hooks

### DIFF
--- a/base/hooks/+pre-commit-and-lfs.sh
+++ b/base/hooks/+pre-commit-and-lfs.sh
@@ -4,5 +4,5 @@
 
 STAGE=$(basename "$0")
 
-exec /opt/git/global-hooks/+pre-commit.sh $STAGE "$@"
+/opt/git/global-hooks/+pre-commit.sh $STAGE "$@"
 exec git lfs $STAGE "${@:2}"


### PR DESCRIPTION
The `+pre-commit-and-lfs.sh` file `exec`-d into pre-commit, and therefore never reached git-lfs. This PR removes exec to fix this.