### PR TITLE
feat: Support xpra as additional connection method for remote containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,15 @@ GIT_PASSWORD ?= password
 # Preferred RDP port on your host system
 RDP_PORT ?= 3390
 
+# Port for access to the xpra htm5 server via nginx
+XPRA_PORT ?= 10000
+
+# Port for direct access to the xpra htm5 server, without authentication!
+# Only enabled in debug routes.
+XPRA_DEBUG_PORT ?= 10001
+
+CONNECTION_METHOD ?= xpra # xpra or xrdp
+
 # External port for web-based containers
 WEB_PORT ?= 8888
 
@@ -312,7 +321,9 @@ run-capella/remote: capella/remote
 	docker run $(DOCKER_RUN_FLAGS) \
 		-v $$(pwd)/volumes/workspace:/workspace \
 		-e RMT_PASSWORD=$(RMT_PASSWORD) \
+		-e CONNECTION_METHOD=$(CONNECTION_METHOD) \
 		-p $(RDP_PORT):3389 \
+		-p $(XPRA_PORT):10000 \
 		-p $(METRICS_PORT):9118 \
 		$(DOCKER_PREFIX)capella/remote:$$(echo "$(DOCKER_TAG_SCHEMA)" | envsubst)
 
@@ -465,6 +476,9 @@ run-t4c/client/exporter: t4c/client/base
 
 debug-capella/base: DOCKER_RUN_FLAGS=-it --entrypoint="bash"
 debug-capella/base: run-capella/base
+
+debug-capella/remote: DOCKER_RUN_FLAGS=-it -p $(XPRA_DEBUG_PORT):10001
+debug-capella/remote: run-capella/remote
 
 debug-t4c/client/backup: LOG_LEVEL=DEBUG
 debug-t4c/client/backup: DOCKER_RUN_FLAGS=-it --entrypoint="bash" -v $$(pwd)/backups/backup.py:/opt/capella/backup.py

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update && \
     git-lfs \
     unzip \
     neovim \
-    zip && \
+    zip \
+    wget && \
     rm -rf /var/lib/apt/lists/*
 
 RUN echo "en_GB.UTF-8 UTF-8" >> /etc/locale.gen && \

--- a/ci-templates/gitlab/image-builder.yml
+++ b/ci-templates/gitlab/image-builder.yml
@@ -84,6 +84,7 @@ variables:
   DOCKER_BUILD_ARGS: "--no-cache"
   BUILD_ARCHITECTURE: amd64
   PURE_VARIANTS_VERSION: "6.0.1"
+  XPRA_REGISTRY: "https://xpra.org"
 
 stages:
   - build
@@ -266,6 +267,7 @@ capella/remote:
       docker build $DOCKER_BUILD_ARGS \
         -t $DOCKER_REGISTRY/capella/remote:$DOCKER_TAG \
         --build-arg BASE_IMAGE=$BASE_IMAGE \
+        --build-arg XPRA_REGISTRY=$XPRA_REGISTRY \
         remote
     - *push
 
@@ -316,6 +318,7 @@ t4c/client/remote:
       docker build $DOCKER_BUILD_ARGS \
         -t $DOCKER_REGISTRY/t4c/client/remote:$DOCKER_TAG \
         --build-arg BASE_IMAGE=$BASE_IMAGE \
+        --build-arg XPRA_REGISTRY=$XPRA_REGISTRY \
         remote
     - *prepare-tests-general
     - pytest -o log_cli=true -s test_t4c_repository_injection.py || r=3
@@ -389,6 +392,7 @@ capella/ease/remote:
       docker build $DOCKER_BUILD_ARGS \
         -t $DOCKER_REGISTRY/capella/ease/remote:$DOCKER_TAG \
         --build-arg BASE_IMAGE=$BASE_IMAGE \
+        --build-arg XPRA_REGISTRY=$XPRA_REGISTRY \
         remote
     - *push
 
@@ -458,6 +462,7 @@ t4c/client/ease/remote:
       docker build $DOCKER_BUILD_ARGS \
         -t $IMAGE:$DOCKER_TAG \
         --build-arg BASE_IMAGE=$BASE_IMAGE \
+        --build-arg XPRA_REGISTRY=$XPRA_REGISTRY \
         remote
     - *push
 
@@ -528,6 +533,7 @@ eclipse/remote:
       docker build $DOCKER_BUILD_ARGS \
         -t ${IMAGE}:${DOCKER_TAG} \
         --build-arg BASE_IMAGE=$BASE_IMAGE \
+        --build-arg XPRA_REGISTRY=$XPRA_REGISTRY \
         remote
     - *push
 
@@ -597,6 +603,7 @@ papyrus/remote:
       docker build $DOCKER_BUILD_ARGS \
         -t ${IMAGE}:${DOCKER_TAG} \
         --build-arg BASE_IMAGE=$BASE_IMAGE \
+        --build-arg XPRA_REGISTRY=$XPRA_REGISTRY \
         remote
     - *push
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+install:
+	python -m venv .venv
+	.venv/bin/pip install -r requirements.txt
+
+serve:
+	.venv/bin/mkdocs serve

--- a/docs/docs/capella/base.md
+++ b/docs/docs/capella/base.md
@@ -103,7 +103,7 @@ If you're missing a dropin in the list, feel free to open a PR.
 #### Optional: Workaround of pinned library versions to remove incompatibilities
 
 **Note:**
-_This workaround is normally handled in the [Dockerfile](capella/Dockerfile) and it is
+_This workaround is normally handled in the Dockerfile and it is
 only necessary to download below libraries if there are restrictions on your network
 that block an access to these libraries when the Docker image is being built._
 

--- a/docs/docs/remote.md
+++ b/docs/docs/remote.md
@@ -11,7 +11,7 @@ The remote images allow to extend the
 - T4C base image (`t4c/client/base`)
 - Pure::variants image (`t4c/client/pure-variants`)
 
-with a RDP server and a metrics endpoint to measure the container activity.
+with a RDP or XPRA server and a metrics endpoint to measure the container activity.
 
 It is a basic Linux server with a [Openbox](http://openbox.org/) installation.
 
@@ -20,6 +20,8 @@ It is a basic Linux server with a [Openbox](http://openbox.org/) installation.
 ### Preparation
 
 #### Optional: Customize Openbox
+
+!!! info "Openbox is only used for the connection method RDP."
 
 Feel free to adjust the configurations `remote/rc.xml` and `remote/menu.xml` to satisfy
 custom Openbox configuration needs.
@@ -36,31 +38,63 @@ where `$BASE_IMAGE` is `capella/base`, `t4c/client/base` or `t4c/client/pure-var
 
 ## Run the container
 
-```zsh
-docker run -d \
-    -p $RDP_EXTERNAL_PORT:3389 \
-    -e RMT_PASSWORD=$RMT_PASSWORD \
-    $BASE_IMAGE/remote
-```
-
 Replace the followings variables:
 
-- `$BASE_IMAGE` with `capella/base`, `t4c/client/base` or `t4c/client/pure-variants`. Please check the `In a remote container (RDP)` on the individual page of the base image for additional configuration options.
-- `$RDP_EXTERNAL_PORT` to the external port for RDP on your host (usually `3389`)
+- `$BASE_IMAGE` with `capella/base`, `t4c/client/base` or `t4c/client/pure-variants`. Please check the individual section `In a remote container (RDP)` of the individual base image documentation pages for additional configuration options.
 - `$RMT_PASSWORD` is the password for remote connections (for the login via RDP) and has
   to be at least 8 characters long.
 
-After starting the container, you should be able to connect to
-`localhost:$RDP_EXTERNAL_PORT` with your preferred RDP Client.
+<!-- prettier-ignore-start -->
+=== "Connect via RDP"
 
-For the login use the followings credentials:
+    The container image contains a `xrdp` server. To use RDP to connect to the container, run the container with the following command:
 
-- **Username**: `techuser`
-- **Password**: `$RMT_PASSWORD`
+    ```zsh
+    docker run -d \
+        -p $RDP_EXTERNAL_PORT:3389 \
+        -e CONNECTION_METHOD=xrdp \
+        -e RMT_PASSWORD=$RMT_PASSWORD \
+        $BASE_IMAGE/remote
+    ```
 
-The screen size is set every time the connection is established. Depending on your
-RDP client, you will also be able to set the preferred screen size in the settings.
+    Replace `$RDP_EXTERNAL_PORT` with the external port that the RDP
+    server should listen on (usually `3389`).
 
-By default, Remmina (RDP client for Linux) starts in a tiny window. To fix that, you can
-easily set "Use client resolution" instead of "Use initial window size" in the remote
-connection profile.
+    After starting the container, you should be able to connect to
+    `localhost:$RDP_EXTERNAL_PORT` with your preferred RDP Client.
+
+    For the login use the followings credentials:
+
+    - **Username**: `techuser`
+    - **Password**: `$RMT_PASSWORD`
+
+    The screen size is set every time the connection is established. Depending on your
+    RDP client, you will also be able to set the preferred screen size in the settings.
+
+    By default, Remmina (RDP client for Linux) starts in a tiny window. To fix that, you can
+    easily set "Use client resolution" instead of "Use initial window size" in the remote
+    connection profile.
+
+
+=== "Connect via XPRA"
+
+    The container image contains a `xpra-html5` server. To use XPRA via HTML5 to connect to the container, run the container with the following command:
+
+    ```zsh
+    docker run -d \
+        -p $XPRA_EXTERNAL_PORT:10000 \
+        -e CONNECTION_METHOD=xpra \
+        -e RMT_PASSWORD=$RMT_PASSWORD \
+        $BASE_IMAGE/remote
+    ```
+
+    Then, open a browser and connect to:
+    ```
+    http://techuser:${RMT_PASSWORD}@localhost:${XPRA_EXTERNAL_PORT}?floating_menu=0
+    ```
+
+    More configuration options can be passed as query parameters.
+    See the [xpra-html5 documentation](https://github.com/Xpra-org/xpra-html5/blob/master/docs/Configuration.md)
+    for more information.
+
+<!-- prettier-ignore-end -->

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -72,6 +72,8 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
 
 extra:
   generator: false

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: CC0-1.0
+
+mkdocs-material>=9.4.0

--- a/remote/Dockerfile
+++ b/remote/Dockerfile
@@ -4,6 +4,12 @@
 ARG BASE_IMAGE=capella/base
 FROM ${BASE_IMAGE}
 
+# Port if xrdp is used as connection method.
+EXPOSE 3389
+
+# Port if xpra is used as connection method.
+EXPOSE 10000
+
 ARG DEBIAN_FRONTEND=noninteractive
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
@@ -12,7 +18,8 @@ ENV SHELL=/bin/bash
 # Install RDP (XRDP with XORG)
 USER root
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+# Install xrdp and dependencies
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     xrdp \
     xserver-xorg-core \
     xorgxrdp \
@@ -21,6 +28,14 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     gettext-base \
     xprintidle \
     nitrogen && rm -rf /var/lib/apt/lists/*
+
+ARG XPRA_REGISTRY=https://xpra.org
+
+# Install xpra and dependencies
+RUN wget -qO /usr/share/keyrings/xpra.asc ${XPRA_REGISTRY}/xpra.asc && \
+    wget -qO /etc/apt/sources.list.d/xpra.sources https://raw.githubusercontent.com/Xpra-org/xpra/master/packaging/repos/bookworm/xpra.sources && \
+    sed -i "s|https://xpra.org|${XPRA_REGISTRY}|" /etc/apt/sources.list.d/xpra.sources && \
+    apt-get update && apt-get install -y --no-install-recommends xpra xpra-x11 xpra-html5 apache2-utils nginx && rm -rf /var/lib/apt/lists/*
 
 COPY rc.xml /etc/xdg/openbox/rc.xml
 COPY menu.xml /etc/xdg/openbox/menu.xml
@@ -32,6 +47,10 @@ COPY bg-saved.cfg /home/techuser/.config/nitrogen/bg-saved.cfg
 # Copy Supervisor Configuration
 RUN pip install --no-cache-dir supervisor==4.2.5
 COPY supervisord.conf /etc/supervisord.conf
+COPY supervisord.*.conf /tmp/supervisord/
+
+# Copy nginx configuration for xpra
+COPY nginx.conf /etc/nginx/nginx.conf
 
 # Allow any user to start the RDP server
 # Depending on the base image used, Xwrapper.config may (not) be available and has to be created.
@@ -42,7 +61,9 @@ RUN sed -i 's/allowed_users=console/allowed_users=anybody/g' /etc/X11/Xwrapper.c
 # Set permissions
 RUN mkdir -p /run/xrdp/sockdir && \
     chown -R techuser /etc/xrdp /run/xrdp /var/log/xrdp* && \
-    chown techuser /var/log
+    chown techuser /var/log && \
+    chown techuser /etc/supervisord.conf /var/log/nginx /var/log/nginx/* && \
+    chown techuser /etc/nginx
 
 WORKDIR /home/techuser
 

--- a/remote/nginx.conf
+++ b/remote/nginx.conf
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+pid /tmp/nginx.pid;
+daemon off;
+events{}
+http {
+    # These options are needed to run as non-root
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp_path;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
+
+    server {
+        listen 10000;
+        server_name _;
+
+        location / {
+            auth_basic "Session access";
+            auth_basic_user_file /etc/nginx/.htpasswd;
+
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+
+            proxy_pass http://127.0.0.1:10001;
+            proxy_buffering off;
+        }
+    }
+}

--- a/remote/startup.sh
+++ b/remote/startup.sh
@@ -16,6 +16,8 @@ else
     exit 1;
 fi
 
+echo "${RMT_PASSWORD:?}" | htpasswd -ci /etc/nginx/.htpasswd techuser
+
 unset RMT_PASSWORD
 
 # Run preparation scripts
@@ -30,5 +32,15 @@ for filename in /opt/setup/*.sh; do
     echo "Executing shell script '$filename'..."
     /bin/bash $filename
 done
+
+# Load supervisord configuration for connection method
+SUPERVISORD_CONFIG_PATH=/tmp/supervisord/supervisord.${CONNECTION_METHOD:-xrdp}.conf
+if [ -f "$SUPERVISORD_CONFIG_PATH" ]; then
+    echo "Adding '$SUPERVISORD_CONFIG_PATH' to configuration."
+    cat $SUPERVISORD_CONFIG_PATH >> /etc/supervisord.conf
+else
+    echo "No '$SUPERVISORD_CONFIG_PATH' found'. Falling back to xrdp configuration."
+    cat /tmp/supervisord/supervisord.xrdp.conf >> /etc/supervisord.conf
+fi
 
 exec supervisord

--- a/remote/supervisord.conf
+++ b/remote/supervisord.conf
@@ -1,17 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-[program:xrdp]
-command=/usr/sbin/xrdp --nodaemon
-user=techuser
-autorestart=true
-
-[program:xrdp-sesman]
-command=/usr/sbin/xrdp-sesman --nodaemon
-user=techuser
-autorestart=true
-environment=DISPLAY=":10"
-
 [program:idletime]
 ; Return idle time of xserver in seconds from xprintidle
 command=python .metrics.py

--- a/remote/supervisord.xpra.conf
+++ b/remote/supervisord.xpra.conf
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+[program:xpra]
+command=xpra start --start=/home/techuser/.config/openbox/autostart --attach=yes --daemon=no --bind-tcp=0.0.0.0:10001
+user=techuser
+autorestart=true
+environment=DISPLAY=":0"
+
+[program:nginx]
+command=nginx
+user=techuser
+autorestart=true

--- a/remote/supervisord.xrdp.conf
+++ b/remote/supervisord.xrdp.conf
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+[program:xrdp]
+command=/usr/sbin/xrdp --nodaemon
+user=techuser
+autorestart=true
+
+[program:xrdp-sesman]
+command=/usr/sbin/xrdp-sesman --nodaemon
+user=techuser
+autorestart=true
+environment=DISPLAY=":10"


### PR DESCRIPTION
[xpra](https://github.com/Xpra-org/xpra/) allows to run X11 programs in the Docker container and expose them to the local host.

We make use of [xpra-html5] client, which allows us to access the application in the browser - without any external software like Guacamole on the way.

xpra runs as non-root out of the box. Basic authentication is handled via nginx.