### PR TITLE
fix: Add `overrideExistingProject` to backup call

### DIFF
--- a/t4c/backup.py
+++ b/t4c/backup.py
@@ -51,6 +51,8 @@ def run_importer_script() -> None:
         OUTPUT_FOLDER,
         "-archiveProject",
         "false",
+        "-overrideExistingProject",
+        "true",
         "-importCommitHistoryAsJson",
         os.getenv("INCLUDE_COMMIT_HISTORY", "true"),
         "-includeCommitHistoryChanges",


### PR DESCRIPTION
This PR adds `-overrideExistingProject` to the backup call which ensures that copying of a project to the output folder does not fail. This ensures that also project having a space in there name are copied correctly.