### PR TITLE
fix: Set `-archiveProject true`to avoid flatten

### DIFF
--- a/base/hooks/+pre-commit-and-lfs.sh
+++ b/base/hooks/+pre-commit-and-lfs.sh
@@ -4,5 +4,5 @@
 
 STAGE=$(basename "$0")
 
-/opt/git/global-hooks/+pre-commit.sh $STAGE "$@"
-exec git lfs $STAGE "${@:2}"
+/opt/git/global-hooks/+pre-commit.sh $STAGE "$@" < /dev/null
+exec git lfs $STAGE "$@"


### PR DESCRIPTION
Previously, the `-archiveProject` flag was set to false. As a result, the project imported from the T4C repository was made available as a simple directory, but all files of the project were flattened. This resulted in a `java.nio.file.File.FileAlreadyExistsException` exception when two images with the same name existed in different locations. This PR changes the `-archiveProject` flag to true, which ensures that the projects are passed as *.zip* files and their original structure is not changed. The archive is then simply unpacked, and as the original structure is retained using `-archiveProject true`, the previous unmessing step (i.e., moving images into a *images* and fragments into a *fragments* directory) is no longer necessary.

Resolves #151