### PR TITLE
fix: Don't encode `@` in project name

### DIFF
--- a/t4c/backup.py
+++ b/t4c/backup.py
@@ -42,7 +42,7 @@ def run_importer_script() -> None:
         "-repoName",
         os.environ["T4C_REPO_NAME"],
         "-projectName",
-        urllib.parse.quote(os.environ["T4C_PROJECT_NAME"]),
+        urllib.parse.quote(os.environ["T4C_PROJECT_NAME"], safe="@"),
         "-importerLogin" if is_capella_5_x_x() else "-repositoryLogin",
         os.environ["T4C_USERNAME"],
         "-importerPassword" if is_capella_5_x_x() else "-repositoryPassword",


### PR DESCRIPTION
T4C uses an intersting encoding for project names described in more detail [here](https://en.wikipedia.org/wiki/Internationalized_Resource_Identifier). Since our projects shouldn't use any special characters anyways, we can avoid reproducing their encoding by simply adding characters to the safe list if encountering a project with such a character.

Resolves #142 