### PR TITLE
feat: Add support to serve xpra on subpath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,9 @@ RDP_PORT ?= 3390
 # Port for access to the xpra htm5 server via nginx
 XPRA_PORT ?= 10000
 
+# Subpath to serve the xpra client on
+XPRA_SUBPATH ?= /xpra
+
 # Port for direct access to the xpra htm5 server, without authentication!
 # Only enabled in debug routes.
 XPRA_DEBUG_PORT ?= 10001
@@ -322,6 +325,7 @@ run-capella/remote: capella/remote
 		-v $$(pwd)/volumes/workspace:/workspace \
 		-e RMT_PASSWORD=$(RMT_PASSWORD) \
 		-e CONNECTION_METHOD=$(CONNECTION_METHOD) \
+		-e XPRA_SUBPATH=$(XPRA_SUBPATH) \
 		-p $(RDP_PORT):3389 \
 		-p $(XPRA_PORT):10000 \
 		-p $(METRICS_PORT):9118 \

--- a/docs/docs/remote.md
+++ b/docs/docs/remote.md
@@ -88,15 +88,18 @@ Replace the followings variables:
 
     ```zsh
     docker run -d \
-        -p $XPRA_EXTERNAL_PORT:10000 \
+        -p $XPRA_PORT:10000 \
         -e CONNECTION_METHOD=xpra \
         -e RMT_PASSWORD=$RMT_PASSWORD \
+        -e XPRA_SUBPATH="/" \
         $BASE_IMAGE/remote
     ```
 
+    Set the `XPRA_SUBPATH` to the subpath that `xpra` should serve on. If you want to have it running on `/xpra`, set `XPRA_SUBPATH` to `/xpra`.
+
     Then, open a browser and connect to:
     ```
-    http://techuser:${RMT_PASSWORD}@localhost:${XPRA_EXTERNAL_PORT}?floating_menu=0
+    http://techuser:${RMT_PASSWORD}@localhost:${XPRA_PORT}${XPRA_SUBPATH}/?floating_menu=0
     ```
 
     More configuration options can be passed as query parameters.

--- a/remote/nginx.conf
+++ b/remote/nginx.conf
@@ -16,7 +16,9 @@ http {
         listen 10000;
         server_name _;
 
-        location / {
+        location __XPRA_SUBPATH__ {
+            rewrite ^__XPRA_SUBPATH__(.*) /$1 break;
+
             auth_basic "Session access";
             auth_basic_user_file /etc/nginx/.htpasswd;
 

--- a/remote/startup.sh
+++ b/remote/startup.sh
@@ -18,6 +18,9 @@ fi
 
 echo "${RMT_PASSWORD:?}" | htpasswd -ci /etc/nginx/.htpasswd techuser
 
+# Replace __XPRA_SUBPATH__ with the actual subpath
+sed -i "s|__XPRA_SUBPATH__|${XPRA_SUBPATH:-/}|g" /etc/nginx/nginx.conf
+
 unset RMT_PASSWORD
 
 # Run preparation scripts


### PR DESCRIPTION
With this commit, it's possible to pass the `XPRA_SUBPATH` variable to define a path that xpra will listen on.