### PR TITLE
fix: Escape project name in pattern

### DIFF
--- a/t4c/backup.py
+++ b/t4c/backup.py
@@ -186,7 +186,9 @@ def clone_git_repository() -> pathlib.Path:
 def unzip_exported_files(project_dir: pathlib.Path) -> None:
     log.info("Start unzipping project archive in %s", project_dir)
 
-    pattern = f"{os.environ['T4C_PROJECT_NAME']}_????????_??????.zip"
+    pattern = (
+        f"{glob.escape(os.environ['T4C_PROJECT_NAME'])}_????????_??????.zip"
+    )
 
     matching_files = glob.glob(pattern, root_dir=project_dir)
 


### PR DESCRIPTION
This PR fixes a problem where reserved pattern symbols like `*` or `[...]` in a project name lead to a problem finding the corresponding archive. More specifically, the pattern for a project named `X_[YZ]_W` previously incorrectly matched `X_Y_W` or `X_Z_W` instead of `X_[YZ]_W`. This is now fixed by correctly escaping the project name.