### PR TITLE
fix: Start xrdp automatically for read-only sessions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,6 +361,7 @@ run-eclipse/remote/pure-variants: eclipse/remote/pure-variants
 run-capella/readonly: capella/readonly
 	docker run $(DOCKER_RUN_FLAGS) \
 		-p $(RDP_PORT):3389 \
+		-p $(XPRA_PORT):10000 \
 		-e RMT_PASSWORD=$(RMT_PASSWORD) \
 		-e GIT_URL=$(GIT_REPO_URL) \
 		-e GIT_ENTRYPOINT=$(GIT_REPO_ENTRYPOINT) \
@@ -368,6 +369,7 @@ run-capella/readonly: capella/readonly
 		-e GIT_DEPTH=$(GIT_REPO_DEPTH) \
 		-e GIT_USERNAME="$(GIT_USERNAME)" \
 		-e GIT_PASSWORD="$(GIT_PASSWORD)" \
+		-e CONNECTION_METHOD=$(CONNECTION_METHOD) \
 		$(DOCKER_PREFIX)capella/readonly:$$(echo "$(DOCKER_TAG_SCHEMA)" | envsubst)
 
 run-capella/readonly-json: capella/readonly

--- a/readonly/Dockerfile
+++ b/readonly/Dockerfile
@@ -10,12 +10,9 @@ ENV SHELL=/bin/bash
 USER root
 
 RUN pip install --no-cache-dir lxml==4.9.3
-COPY load_models.py /opt/scripts/load_models.py
-RUN chown -R techuser /opt/capella
 ENV EASE_LOG_LOCATION=/proc/1/fd/1
 
-COPY startup.sh /home/techuser/.startup.sh
-RUN chmod 755 /home/techuser/.startup.sh
+COPY load_models.py /opt/scripts/load_models.py
+COPY prepare_workspace.sh /opt/setup/prepare_workspace.sh
 
 USER techuser
-ENTRYPOINT [ "/home/techuser/.startup.sh" ]

--- a/readonly/prepare_workspace.sh
+++ b/readonly/prepare_workspace.sh
@@ -5,15 +5,7 @@
 
 set -exuo pipefail
 
-salt=$(openssl rand -base64 16)
-password_hash=$(openssl passwd -6 -salt ${salt} "${RMT_PASSWORD:?}")
-line=$(grep techuser /etc/shadow);
-echo ${line%%:*}:${password_hash}:${line#*:*:} > /etc/shadow;
-unset RMT_PASSWORD
-
-# Prepare Workspace
 echo "---START_PREPARE_WORKSPACE---"
-export DISPLAY=:99
 xvfb-run /opt/capella/capella -clean -data ${WORKSPACE_DIR:-/workspace} --launcher.suppressErrors -nosplash -consolelog -application org.eclipse.ease.runScript -script "file:/opt/scripts/load_models.py";
 if [[ "$?" == 0 ]]
 then
@@ -26,5 +18,3 @@ fi
 unset GIT_USERNAME GIT_PASSWORD GIT_ASKPASS GIT_REPOS_JSON
 
 echo "---START_SESSION---"
-
-exec supervisord

--- a/remote/startup.sh
+++ b/remote/startup.sh
@@ -30,7 +30,7 @@ done
 for filename in /opt/setup/*.sh; do
     [ -e "$filename" ] || continue
     echo "Executing shell script '$filename'..."
-    /bin/bash $filename
+    source $filename
 done
 
 # Load supervisord configuration for connection method


### PR DESCRIPTION
After xpra support was introduced, the `supervisord` configuration was split into general, xrdp and xpra. Unfortunately, I forgot to load the new configuration files into the read-only images. As a result, neither xrdp nor xpra were started.

Another good side effect of this fix is that xpra is now supported for read-only sessions. I was also able to eliminate some code duplication by reusing the startup script from the remote container.