### PR TITLE
feat: Allow embedding in iframes with cookie-based authentication

### DIFF
--- a/docs/docs/capella/base.md
+++ b/docs/docs/capella/base.md
@@ -88,7 +88,7 @@ To customise the Capella client you can
 ##### Install dropins
 
 As alternative to the solution presented above, we provide an interface to
-install dropins easily.
+install dropins.
 
 You have to pass a comma-separated list of dropin names as `CAPELLA_DROPINS`
 build argument to the `docker build` command:

--- a/docs/docs/remote.md
+++ b/docs/docs/remote.md
@@ -50,7 +50,6 @@ Replace the followings variables:
 - `$RMT_PASSWORD` is the password for remote connections (for the login via
   RDP) and has to be at least 8 characters long.
 
-<!-- prettier-ignore-start -->
 === "Connect via RDP"
 
     The container image contains a `xrdp` server. To use RDP to connect to the container, run the container with the following command:
@@ -78,9 +77,8 @@ Replace the followings variables:
     RDP client, you will also be able to set the preferred screen size in the settings.
 
     By default, Remmina (RDP client for Linux) starts in a tiny window. To fix that, you can
-    easily set "Use client resolution" instead of "Use initial window size" in the remote
+    set "Use client resolution" instead of "Use initial window size" in the remote
     connection profile.
-
 
 === "Connect via XPRA"
 
@@ -95,15 +93,26 @@ Replace the followings variables:
         $BASE_IMAGE/remote
     ```
 
+    !!! note "Authentication"
+
+        The mentioned command uses a cookie-based authentication method. You have to pass a cookie with the key `token` and the value `$RMT_PASSWORD`.
+        To set the cookie manually, you can use browser extensions like [EditThisCookie](https://github.com/ETCExtensions/Edit-This-Cookie).
+
+        If you want to disable authentication for local development, you can expose the container internal port 10001 instead of port 10000.
+        Note that other flags like `XPRA_SUBPATH` won't work in this case.
+
+    !!! note "Embedding in iframes"
+
+        To embed the XPRA session in an iframe, you have to set a custom Content Security Policy. You can pass the environment variable `XPRA_CSP_ORIGIN_HOST`
+        with the hostname of the website you'd like to embed the XPRA session in. If you want to embed the XPRA session in an iframe on `example.com`, set `XPRA_CSP_ORIGIN_HOST` to `https://example.com`.
+
     Set the `XPRA_SUBPATH` to the subpath that `xpra` should serve on. If you want to have it running on `/xpra`, set `XPRA_SUBPATH` to `/xpra`.
 
     Then, open a browser and connect to:
     ```
-    http://techuser:${RMT_PASSWORD}@localhost:${XPRA_PORT}${XPRA_SUBPATH}/?floating_menu=0
+    http://localhost:${XPRA_PORT}${XPRA_SUBPATH}/?floating_menu=0
     ```
 
     More configuration options can be passed as query parameters.
     See the [xpra-html5 documentation](https://github.com/Xpra-org/xpra-html5/blob/master/docs/Configuration.md)
     for more information.
-
-<!-- prettier-ignore-end -->

--- a/remote/nginx.conf
+++ b/remote/nginx.conf
@@ -16,11 +16,12 @@ http {
         listen 10000;
         server_name _;
 
+        if ($cookie_token !~ '__XPRA_TOKEN__') {
+            return 401;
+        }
+
         location __XPRA_SUBPATH__ {
             rewrite ^__XPRA_SUBPATH__(.*) /$1 break;
-
-            auth_basic "Session access";
-            auth_basic_user_file /etc/nginx/.htpasswd;
 
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -29,6 +30,9 @@ http {
 
             proxy_pass http://127.0.0.1:10001;
             proxy_buffering off;
+
+            proxy_hide_header Content-Security-Policy;
+            add_header Content-Security-Policy "frame-ancestors self __XPRA_CSP_ORIGIN_HOST__";
         }
     }
 }

--- a/remote/startup.sh
+++ b/remote/startup.sh
@@ -16,10 +16,10 @@ else
     exit 1;
 fi
 
-echo "${RMT_PASSWORD:?}" | htpasswd -ci /etc/nginx/.htpasswd techuser
-
-# Replace __XPRA_SUBPATH__ with the actual subpath
+# Replace Variables in the nginx.conf
 sed -i "s|__XPRA_SUBPATH__|${XPRA_SUBPATH:-/}|g" /etc/nginx/nginx.conf
+sed -i "s|__XPRA_TOKEN__|${RMT_PASSWORD:-/}|g" /etc/nginx/nginx.conf
+sed -i "s|__XPRA_CSP_ORIGIN_HOST__|${XPRA_CSP_ORIGIN_HOST:-}|g" /etc/nginx/nginx.conf
 
 unset RMT_PASSWORD
 


### PR DESCRIPTION
Instead of the basic authentication, we switch the authentication method to cookie based authentication. This makes the embedding in iframes easier.

In addition, the Content-Security-Policy origin host can be defined via the environment variable `XPRA_CSP_ORIGIN_HOST`.