### PR TITLE
feat: Remove `HTTP` related code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,6 @@ T4C_USERNAME ?= admin
 # T4C password
 T4C_PASSWORD ?= admin
 
-# Connection type to T4C server
-CONNECTION_TYPE ?= telnet
-
 # Remote container rdp password
 RMT_PASSWORD ?= tmp_passwd2
 

--- a/Makefile
+++ b/Makefile
@@ -22,15 +22,6 @@ T4C_USERNAME ?= admin
 # T4C password
 T4C_PASSWORD ?= admin
 
-# T4C http port
-HTTP_PORT ?= 8080
-
-# T4C http username
-HTTP_LOGIN ?= admin
-
-# T4C http password
-HTTP_PASSWORD ?= password
-
 # Connection type to T4C server
 CONNECTION_TYPE ?= telnet
 
@@ -431,11 +422,7 @@ run-t4c/client/backup: t4c/client/base
 		-e T4C_PASSWORD="$(T4C_PASSWORD)" \
 		-e GIT_USERNAME="$(GIT_USERNAME)" \
 		-e GIT_PASSWORD="$(GIT_PASSWORD)" \
-		-e HTTP_LOGIN="$(HTTP_LOGIN)" \
-		-e HTTP_PASSWORD="$(HTTP_PASSWORD)" \
-		-e HTTP_PORT="$(HTTP_PORT)" \
 		-e LOG_LEVEL="$(LOG_LEVEL)" \
-		-e CONNECTION_TYPE="$(CONNECTION_TYPE)" \
 		$(DOCKER_PREFIX)t4c/client/base:$$(echo "$(DOCKER_TAG_SCHEMA)" | envsubst) backup
 
 run-t4c/client/backup-local: t4c/client/base
@@ -448,11 +435,7 @@ run-t4c/client/backup-local: t4c/client/base
 		-e T4C_PROJECT_NAME="$(T4C_IMPORTER_PROJECT)" \
 		-e T4C_USERNAME="$(T4C_USERNAME)" \
 		-e T4C_PASSWORD="$(T4C_PASSWORD)" \
-		-e HTTP_LOGIN="$(HTTP_LOGIN)" \
-		-e HTTP_PASSWORD="$(HTTP_PASSWORD)" \
-		-e HTTP_PORT="$(HTTP_PORT)" \
 		-e LOG_LEVEL="$(LOG_LEVEL)" \
-		-e CONNECTION_TYPE="$(CONNECTION_TYPE)" \
 		$(DOCKER_PREFIX)t4c/client/base:$$(echo "$(DOCKER_TAG_SCHEMA)" | envsubst) backup
 
 run-t4c/client/exporter: t4c/client/base
@@ -468,9 +451,6 @@ run-t4c/client/exporter: t4c/client/base
 		-e T4C_PROJECT_NAME="$(T4C_IMPORTER_PROJECT)" \
 		-e T4C_USERNAME="$(T4C_USERNAME)" \
 		-e T4C_PASSWORD="$(T4C_PASSWORD)" \
-		-e HTTP_PORT="${HTTP_PORT}" \
-		-e HTTP_LOGIN="${HTTP_LOGIN}" \
-		-e HTTP_PASSWORD="${HTTP_PASSWORD}" \
 		-e LOG_LEVEL="$(LOG_LEVEL)" \
 		$(DOCKER_PREFIX)t4c/client/base:$$(echo "$(DOCKER_TAG_SCHEMA)" | envsubst) export
 

--- a/ci-templates/gitlab/exporter.yml
+++ b/ci-templates/gitlab/exporter.yml
@@ -57,16 +57,6 @@ export-to-t4c:
     # T4C password (for repository login)
     # T4C_PASSWORD: ${T4C_PASSWORD}
 
-    # HTTP username
-    # HTTP_LOGIN: ${HTTP_LOGIN}
-
-    # HTTP password
-    # HTTP_PASSWORD: ${HTTP_PASSWORD}
-
-    # HTTP Port (port for REST API endpoint)
-    # Defaults to 8080
-    # HTTP_PORT: 8080
-
     # Log level. All Python `logging` levels are allowed.
     # Defaults to INFO
     LOG_LEVEL: INFO

--- a/docs/docs/capella/t4c/exporter.md
+++ b/docs/docs/capella/t4c/exporter.md
@@ -38,17 +38,9 @@ docker run -d \
   -e T4C_PROJECT_NAME=test \
   -e T4C_USERNAME=user \
   -e T4C_PASSWORD=password \
-  -e HTTP_PORT=8080 \
-  -e HTTP_LOGIN=admin \
-  -e HTTP_PASSWORD=password \
   -e LOG_LEVEL=DEBUG \
   t4c/client/base export
 ```
 
-You can find the description for most of the values in the run instructions of
-the [importer](./importer.md#run-the-container). These are the additional ones:
-
-- `HTTP_PORT`: port to the T4C http server
-- `HTTP_LOGIN`: username for the REST API. At the moment administrator access
-  is required
-- `HTTP_PASSWORD`: password for the REST API
+You can find the description for these values in the run instructions of the
+[importer](./importer.md#run-the-container).

--- a/docs/docs/capella/t4c/importer.md
+++ b/docs/docs/capella/t4c/importer.md
@@ -59,7 +59,6 @@ Set the following values for the corresponding keys:
   Capella to connect to a remote repository.
 - `T4C_REPO_PORT`: port to the T4C server. The same value that you enter in
   Capella to connect to a remote repository. Defaults to 2036.
-- `T4C_CDO_PORT`: CDO port to the T4C server. Defaults to 12036.
 - `T4C_REPO_NAME`: T4C repository name. The same value that you enter in
   Capella to connect to a remote repository.
 - `T4C_PROJECT_NAME`: name of the Capella project. It's displayed in the

--- a/docs/docs/ci-templates/gitlab/t4c-export.md
+++ b/docs/docs/ci-templates/gitlab/t4c-export.md
@@ -25,7 +25,6 @@ In addition, you have to add the following environment variables on repository
 level. Make sure to enable the "Expand variable reference" flag.
 
 - `CAPELLA_DOCKER_IMAGES_REVISION`: Revision of this Github repository
-- `HTTP_LOGIN` and `HTTP_PASSWORD`: Username / password for the T4C REST API
 - `T4C_USERNAME` and `T4C_PASSWORD`: Username / password for the T4C repository
 
 This is the minimal configuration. For more advanced configuration options,

--- a/t4c/backup.py
+++ b/t4c/backup.py
@@ -21,8 +21,6 @@ OUTPUT_FOLDER: str = "/tmp/model"
 def run_importer_script() -> None:
     log.debug("Import model from TeamForCapella server...")
 
-    connection_type: str = get_connection_type()
-
     command: list[str] = [
         "/opt/capella/capella",
         "--launcher.suppressErrors",
@@ -60,22 +58,6 @@ def run_importer_script() -> None:
         "-backupDBOnFailure",
         "false",
     ]
-
-    if connection_type == "telnet":
-        command += [
-            "-consoleport",
-            os.getenv("T4C_CDO_PORT", "12036"),
-        ]
-    else:
-        http_login, http_password, http_port = get_http_envs()
-        command += [
-            "-httpLogin",
-            http_login,
-            "-httpPassword",
-            http_password,
-            "-httpPort",
-            http_port,
-        ]
 
     log.info("Executing the following command: %s", " ".join(command))
 
@@ -294,42 +276,12 @@ def git_commit_and_push(git_dir: pathlib.Path) -> None:
         log.warning("No changes, will not commit.")
 
 
-def get_connection_type() -> str:
-    default_connection_type: str = "telnet" if is_capella_5_x_x() else "http"
-    connection_type: str = os.getenv(
-        "CONNECTION_TYPE", default_connection_type
-    )
-
-    if connection_type not in ("telnet", "http"):
-        raise ValueError(
-            'CONNECTION_TYPE is only allowed to be: "telnet", "http"'
-        )
-
-    if connection_type == "http" and is_capella_5_x_x():
-        raise ValueError('CONNECTION_TYPE must be "telnet" for capella 5.x.x')
-
-    return connection_type
-
-
 def is_capella_5_x_x() -> bool:
     return bool(re.match(r"5.[0-9]+.[0-9]+", os.getenv("CAPELLA_VERSION", "")))
 
 
 def is_capella_5_0_x() -> bool:
     return bool(re.match(r"5.0.[0-9]+", os.getenv("CAPELLA_VERSION", "")))
-
-
-def get_http_envs() -> tuple[str, str, str]:
-    http_login = os.getenv("HTTP_LOGIN")
-    http_password = os.getenv("HTTP_PASSWORD")
-    http_port = os.getenv("HTTP_PORT")
-
-    if not (http_login and http_password and http_port):
-        raise ValueError(
-            "HTTP_LOGIN, HTTP_PASSWORD, HTTP_PORT must be specified"
-        )
-
-    return (http_login, http_password, http_port)
 
 
 if __name__ == "__main__":

--- a/t4c/export.py
+++ b/t4c/export.py
@@ -118,12 +118,6 @@ def run_exporter_script(model_dir: pathlib.Path) -> None:
         os.environ["T4C_USERNAME"],
         "-repositoryPassword",
         os.environ["T4C_PASSWORD"],
-        "-httpLogin",
-        os.environ["HTTP_LOGIN"],
-        "-httpPassword",
-        os.environ["HTTP_PASSWORD"],
-        "-httpPort",
-        os.environ["HTTP_PORT"],
         "-sourceToExport",
         str(model_dir),
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,10 @@ def fixture_init_git_server(
 
 @pytest.fixture(name="t4c_server_env")
 def fixture_t4c_server_env(request: pytest.FixtureRequest) -> dict[str, str]:
-    env: dict[str, str] = {"REST_API_PASSWORD": "password"}
+    env: dict[str, str] = {
+        "REST_API_PASSWORD": "password",
+        "ENABLE_CDO": "false",
+    }
 
     if hasattr(request, "param"):
         env = env | request.param
@@ -183,17 +186,6 @@ def fixture_t4c_general_env(t4c_ip_addr: str) -> dict[str, str]:
         "T4C_PASSWORD": T4C_PASSWORD,
         "INCLUDE_COMMIT_HISTORY": "false",
         "LOG_LEVEL": "INFO",
-    }
-
-
-@pytest.fixture(name="t4c_exporter_env")
-def fixture_t4c_exporter_env(
-    t4c_general_env: dict[str, str]
-) -> dict[str, str]:
-    return t4c_general_env | {
-        "HTTP_LOGIN": HTTP_LOGIN,
-        "HTTP_PASSWORD": HTTP_PASSWORD,
-        "HTTP_PORT": "8080",
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,7 +179,6 @@ def fixture_t4c_general_env(t4c_ip_addr: str) -> dict[str, str]:
     return {
         "T4C_REPO_HOST": t4c_ip_addr,
         "T4C_REPO_PORT": "2036",
-        "T4C_CDO_PORT": "12036",
         "T4C_REPO_NAME": T4C_REPO_NAME,
         "T4C_PROJECT_NAME": T4C_PROJECT_NAME,
         "T4C_USERNAME": T4C_USERNAME,

--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -44,11 +44,7 @@ def fixture_t4c_backup_container(
 
 @pytest.mark.parametrize(
     "t4c_server_container",
-    [
-        pytest.param(
-            {"init": True},
-        )
-    ],
+    [{"init": True}],
     indirect=True,
 )
 def test_model_backup_happy(

--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -23,14 +23,9 @@ def fixture_t4c_backup_local_env(
     git_general_env: dict[str, str],
     t4c_general_env: dict[str, str],
     t4c_ip_addr: str,
-    request: pytest.FixtureRequest,
 ) -> dict[str, str]:
     env: dict[str, str] = git_general_env | t4c_general_env
-
     env["no_proxy"] = t4c_ip_addr
-
-    if hasattr(request, "param"):
-        env = env | request.param
 
     return env
 
@@ -48,36 +43,11 @@ def fixture_t4c_backup_container(
 
 
 @pytest.mark.parametrize(
-    "t4c_server_container,t4c_server_env,t4c_backup_local_env",
+    "t4c_server_container",
     [
         pytest.param(
             {"init": True},
-            {"ENABLE_CDO": "true"},
-            {"CONNECTION_TYPE": "telnet"},
-        ),
-        pytest.param(
-            {"init": True},
-            {"ENABLE_CDO": "false"},
-            {"CONNECTION_TYPE": "telnet"},
-            marks=pytest.mark.skipif(
-                condition=conftest.is_capella_6_x_x(),
-                reason="CDO disabled by default for capella >= 6.0.0",
-            ),
-        ),
-        pytest.param(
-            {"init": True},
-            {"ENABLE_CDO": "false"},
-            {
-                "CONNECTION_TYPE": "http",
-                "HTTP_LOGIN": "admin",
-                "HTTP_PASSWORD": "password",
-                "HTTP_PORT": "8080",
-            },
-            marks=pytest.mark.skipif(
-                condition=conftest.is_capella_5_x_x(),
-                reason="conncetion type http is not supported for capella < 6.0.0",
-            ),
-        ),
+        )
     ],
     indirect=True,
 )
@@ -127,23 +97,3 @@ def test_model_backup_happy(
     assert os.path.exists(git_path / "test-project.afm")
     assert os.path.exists(git_path / "test-project.aird")
     assert os.path.exists(git_path / "test-project.capella")
-
-
-@pytest.mark.parametrize(
-    "t4c_server_container,t4c_server_env,t4c_backup_local_env",
-    [
-        # CONNECTION_TYPE "unknown" is not allowed
-        (
-            {"init": True},
-            {"ENABLE_CDO": "true"},
-            {"CONNECTION_TYPE": "unknown"},
-        ),
-        ({"init": True}, {"ENABLE_CDO": "false"}, {"CONNECTION_TYPE": "http"}),
-    ],
-    indirect=True,
-)
-def test_model_backup_unhappy(t4c_backup_container):
-    with pytest.raises(RuntimeError):
-        conftest.wait_for_container(
-            t4c_backup_container, "Backup of model finished"
-        )

--- a/tests/test_exporter_git.py
+++ b/tests/test_exporter_git.py
@@ -18,13 +18,11 @@ pytestmark = pytest.mark.t4c_server
 @pytest.fixture(name="t4c_exporter_git_env")
 def fixture_t4c_exporter_git_env(
     git_general_env: dict[str, str],
-    t4c_exporter_env: dict[str, str],
+    t4c_general_env: dict[str, str],
     request: pytest.FixtureRequest,
 ) -> dict[str, str]:
     env: dict[str, str] = (
-        t4c_exporter_env
-        | git_general_env
-        | {"ENTRYPOINT": conftest.ENTRYPOINT}
+        t4c_general_env | git_general_env | {"ENTRYPOINT": conftest.ENTRYPOINT}
     )
 
     if hasattr(request, "param"):

--- a/tests/test_exporter_local.py
+++ b/tests/test_exporter_local.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import difflib
 import logging
 import os
 import pathlib
@@ -13,7 +12,6 @@ import capellambse
 import capellambse.decl
 import conftest
 import pytest
-from capellambse.loader import exs
 
 log = logging.getLogger(__file__)
 log.setLevel("DEBUG")
@@ -25,10 +23,10 @@ TECHUSER_UID: str | int = os.getenv("TECHUSER_UID", "")
 
 @pytest.fixture(name="t4c_exporter_local_env")
 def fixture_t4c_exporter_local_env(
-    t4c_exporter_env: dict[str, str],
+    t4c_general_env: dict[str, str],
     t4c_ip_addr: str,
 ) -> dict[str, str]:
-    return t4c_exporter_env | {
+    return t4c_general_env | {
         "FILE_HANDLER": "local",
         "no_proxy": t4c_ip_addr,
     }
@@ -147,31 +145,3 @@ def copy_model_files_to_directory(
     for file in model_dir.glob("*"):
         if not str(file).endswith("license"):
             shutil.copy2(file, tar_dir)
-
-
-def _create_model_diff(
-    model_1: capellambse.MelodyModel,
-    model_2: capellambse.MelodyModel,
-    path: pathlib.Path,
-    suffix: int | str | None = None,
-):
-    differ: difflib.Differ = difflib.Differ()
-
-    diff_file_path: pathlib.Path = path / "diff.xml"
-    if suffix is not None:
-        diff_file_path = path / f"diff_{suffix}.xml"
-
-    model_diff = differ.compare(
-        exs.to_string(model_1._element).splitlines(True),
-        exs.to_string(model_2._element).splitlines(True),
-    )
-
-    with open(diff_file_path, "w", encoding="UTF-8") as diff_file:
-        diff_file.write("".join(model_diff))
-
-
-def _clear_files_and_delete_directory(model_dir: pathlib.Path):
-    for file in model_dir.glob("*"):
-        if file.is_file():
-            file.unlink()
-    model_dir.rmdir()


### PR DESCRIPTION
This PR removes any code and related documentation that used the `HTTP` variables. This is possible because no T4C administrator operation should be performed in both the backup and export scripts, so we do not need to provide these variables. The fact that this is possible was discovered in https://github.com/DSD-DBS/capella-dockerimages/pull/249 and described in https://github.com/DSD-DBS/capella-dockerimages/issues/253.

I have successfully run all tests for version 5.2.0, 6.0.0 and 6.1.0 locally.

Resolves #253 