### PR TITLE
fix: Set `xpra-html5` version to `v10.1`

### DIFF
--- a/remote/Dockerfile
+++ b/remote/Dockerfile
@@ -59,6 +59,7 @@ COPY supervisord.*.conf /tmp/supervisord/
 
 # Copy nginx configuration for xpra
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY error.html /usr/share/nginx/html/error.html
 
 # Allow any user to start the RDP server
 # Depending on the base image used, Xwrapper.config may (not) be available and has to be created.

--- a/remote/Dockerfile
+++ b/remote/Dockerfile
@@ -35,7 +35,15 @@ ARG XPRA_REGISTRY=https://xpra.org
 RUN wget -qO /usr/share/keyrings/xpra.asc ${XPRA_REGISTRY}/xpra.asc && \
     wget -qO /etc/apt/sources.list.d/xpra.sources https://raw.githubusercontent.com/Xpra-org/xpra/master/packaging/repos/bookworm/xpra.sources && \
     sed -i "s|https://xpra.org|${XPRA_REGISTRY}|" /etc/apt/sources.list.d/xpra.sources && \
-    apt-get update && apt-get install -y --no-install-recommends xpra xpra-x11 xpra-html5 apache2-utils nginx && rm -rf /var/lib/apt/lists/*
+    apt-get update && \
+    apt-get install -y \
+        --no-install-recommends \
+        xpra \
+        xpra-x11 \
+        xpra-html5=10.1-r10-1 \
+        apache2-utils \
+        nginx && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY rc.xml /etc/xdg/openbox/rc.xml
 COPY menu.xml /etc/xdg/openbox/menu.xml

--- a/remote/error.html
+++ b/remote/error.html
@@ -1,0 +1,24 @@
+<!--
+ ~ SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+ ~ SPDX-License-Identifier: Apache-2.0
+ -->
+
+<!doctype html>
+<html>
+  <head>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>Xpra is not ready - 502 Bad Gateway</h2>
+
+    <div>If you started the session recently, it is not ready yet.</div>
+    <div>Refresh the page in a few seconds.</div>
+    <div>
+      If this error is persistent, please contact your system administrator.
+    </div>
+  </body>
+</html>

--- a/remote/nginx.conf
+++ b/remote/nginx.conf
@@ -16,6 +16,10 @@ http {
         listen 10000;
         server_name _;
 
+        root /usr/share/nginx/html;
+        error_page 502 /error.html;
+        error_page 404 /error.html;
+
         if ($cookie_token !~ '__XPRA_TOKEN__') {
             return 401;
         }


### PR DESCRIPTION
Version 11 doesn't respect the URI parameters and the floating window is not disabled.
Version 12 doesn't connect to the session. Since it's still in beta, we should use it anyway.
