### PR TITLE
feat: Add custom error message during Xpra startup

### DIFF
--- a/remote/Dockerfile
+++ b/remote/Dockerfile
@@ -59,6 +59,7 @@ COPY supervisord.*.conf /tmp/supervisord/
 
 # Copy nginx configuration for xpra
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY error.html /usr/share/nginx/html/error.html
 
 # Allow any user to start the RDP server
 # Depending on the base image used, Xwrapper.config may (not) be available and has to be created.

--- a/remote/error.html
+++ b/remote/error.html
@@ -1,0 +1,24 @@
+<!--
+ ~ SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+ ~ SPDX-License-Identifier: Apache-2.0
+ -->
+
+<!doctype html>
+<html>
+  <head>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>Xpra is not ready - 502 Bad Gateway</h2>
+
+    <div>If you started the session recently, it is not ready yet.</div>
+    <div>Refresh the page in a few seconds.</div>
+    <div>
+      If this error is persistent, please contact your system administrator.
+    </div>
+  </body>
+</html>

--- a/remote/nginx.conf
+++ b/remote/nginx.conf
@@ -16,6 +16,10 @@ http {
         listen 10000;
         server_name _;
 
+        root /usr/share/nginx/html;
+        error_page 502 /error.html;
+        error_page 404 /error.html;
+
         if ($cookie_token !~ '__XPRA_TOKEN__') {
             return 401;
         }


### PR DESCRIPTION
When xpra is starting, it can lead to occasional 502 and 404 errors. This is nothing to worry about, but hard to understand for users. Therefore, we make the error a bit clearer.

![image](https://github.com/DSD-DBS/capella-dockerimages/assets/23395732/80efb5ac-c895-444f-9372-a5aba3eadc4c)
