### PR TITLE
docs: Disable font-loading from Google Fonts

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -4,6 +4,7 @@
 site_name: MBSE Docker images
 theme:
   name: material
+  font: false
   palette:
     scheme: slate
     primary: indigo
@@ -33,7 +34,7 @@ nav:
       - CLI: capella/cli.md
       - EASE: ease.md
       - Read-only: capella/readonly.md
-      - "pure::variants": pure-variants.md
+      - 'pure::variants': pure-variants.md
       - Build from source: capella/build-from-source.md
       - Team4Capella client:
           - Introduction: capella/t4c/introduction.md
@@ -46,7 +47,7 @@ nav:
       - Base: papyrus/base.md
   - Eclipse:
       - Base: eclipse/base.md
-      - "pure::variants": pure-variants.md
+      - 'pure::variants': pure-variants.md
   - Remote: remote.md
 
 repo_url: https://github.com/DSD-DBS/capella-dockerimages


### PR DESCRIPTION
Loading fonts from Google Fonts is not GDPR compliant. The documentation will now use the system-font.