### PR TITLE
feat: Open commit description window on save

### DIFF
--- a/t4c/setup_workspace_t4c.py
+++ b/t4c/setup_workspace_t4c.py
@@ -103,5 +103,10 @@ if __name__ == "__main__":
         os.getenv("T4C_SERVER_HOST", "localhost"),
     )
 
+    # Automatically open the commit description window when saving
+    replace_config(
+        OBEO_COLLAB_CONF, "PREF_ENABLE_DESCRIPTION_ON_COMMIT", "true"
+    )
+
     # Set default repositories in selection dialog
     setup_repositories()


### PR DESCRIPTION
This forces the description window to pop up automatically when you save a change. This is done because it is quite difficult to find this setting on your own, especially if you do not know about it in the first place. In addition, the window still offers the option to simply ignore providing a description, so the previous default behavior is still included. However, it usually makes sense to provide a description, so this is now much easier to do.