### PR TITLE
feat(t4c): Provide credentials via a file

### DIFF
--- a/t4c/t4c_cli/backup.py
+++ b/t4c/t4c_cli/backup.py
@@ -40,17 +40,11 @@ def _build_backup_command(
         "-projectName",
         urllib.parse.quote(t4c_config.project_name, safe="@"),
         (
-            "-importerLogin"
+            "-importerCredentials"
             if util_capella.is_capella_5_x_x()
-            else "-repositoryLogin"
+            else "-repositoryCredentials"
         ),
-        t4c_config.username,
-        (
-            "-importerPassword"
-            if util_capella.is_capella_5_x_x()
-            else "-repositoryPassword"
-        ),
-        t4c_config.password,
+        t4c_config.credentials_file_path,
         "-outputFolder",
         t4c_config.project_dir_path,
         "-archiveProject",

--- a/t4c/t4c_cli/export.py
+++ b/t4c/t4c_cli/export.py
@@ -40,10 +40,8 @@ def _build_export_command(model_dir: pathlib.Path) -> list[str]:
         t4c_config.repo_port,
         "-repoName",
         t4c_config.repo_name,
-        "-repositoryLogin",
-        t4c_config.username,
-        "-repositoryPassword",
-        t4c_config.password,
+        "-repositoryCredentials",
+        t4c_config.credentials_file_path,
         "-sourceToExport",
         str(model_dir),
     ]

--- a/t4c/t4c_cli/util/config.py
+++ b/t4c/t4c_cli/util/config.py
@@ -29,11 +29,16 @@ class T4CConfig:
     repo_host: str = os.environ["T4C_REPO_HOST"]
     repo_port: str = os.getenv("T4C_REPO_PORT", "2036")
     repo_name: str = os.environ["T4C_REPO_NAME"]
-    username: str = os.environ["T4C_USERNAME"]
-    password: str = os.environ["T4C_PASSWORD"]
+    credentials_file_path: str = "/tmp/t4c_credentials"
     include_commit_history = str_to_bool(
         os.getenv("INCLUDE_COMMIT_HISTORY", "false")
     )
+
+    def __init__(self) -> None:
+        with open(self.credentials_file_path, "w", encoding="utf-8") as file:
+            file.write(
+                f"{os.environ['T4C_USERNAME']}:{os.environ['T4C_PASSWORD']}"
+            )
 
 
 class CapellaConfig:


### PR DESCRIPTION
This removes the direct use of `T4C_USERNAME` and `T4C_PASSWORD` within the T4C CLI and instead writes them to a file and then uses that file. This has the advantage that the credentials are no longer displayed directly within the command, reducing the risk of potential exposure, and is also the recommended way to provide the credentials described by OBEO.

All tests for versions 5.2.0, 6.0.0 and 6.1.0 were successful.

Resolves #270 