### PR TITLE
feat: Allow additional dependencies during runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -457,6 +457,9 @@ debug-eclipse/remote/pure-variants: AUTOSTART_ECLIPSE=0
 debug-eclipse/remote/pure-variants: DOCKER_RUN_FLAGS=$(DOCKER_DEBUG_FLAGS)
 debug-eclipse/remote/pure-variants: run-eclipse/remote/pure-variants
 
+debug-jupyter-notebook: DOCKER_RUN_FLAGS=$(DOCKER_DEBUG_FLAGS)
+debug-jupyter-notebook: run-jupyter-notebook
+
 t4c/server/server: SHELL=./capella_loop.sh
 t4c/server/server:
 	$(MAKE) -C t4c/server PUSH_IMAGES=$(PUSH_IMAGES) CAPELLA_VERSION=$$CAPELLA_VERSION $@

--- a/docs/docs/jupyter/index.md
+++ b/docs/docs/jupyter/index.md
@@ -30,3 +30,7 @@ The following environment variables can be defined:
 - `JUPYTER_BASE_URL`: A context path to access the jupyter server. This allows
   you to run multiple server containers on the same domain.
 - `JUPYTER_TOKEN`: A token for accessing the environment.
+- `JUPYTER_ADDITIONAL_DEPENDENCIES`: A space-separated list of additional pip
+  dependencies to install. The variable is passed to the `pip install -U`
+  command and may include additional flags. The value is not escaped, only use
+  trusted values.

--- a/jupyter-notebook/Dockerfile
+++ b/jupyter-notebook/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && \
     libcairo2-dev \
     gir1.2-pango-1.0 \
     curl \
+    weasyprint \
     graphviz && \
     rm -rf /var/lib/apt/lists/*
 
@@ -54,5 +55,7 @@ ENV WORKSPACE_DIR=/workspace/notebooks
 EXPOSE $JUPYTER_PORT
 
 WORKDIR $HOME
+
+ENV JUPYTER_ADDITIONAL_DEPENDENCIES=""
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/jupyter-notebook/docker-entrypoint.sh
+++ b/jupyter-notebook/docker-entrypoint.sh
@@ -17,8 +17,11 @@ echo "---START_PREPARE_WORKSPACE---"
 
 mkdir -p "$WORKSPACE_DIR"
 
+[[ -z "$JUPYTER_ADDITIONAL_DEPENDENCIES" ]] || pip install -U $JUPYTER_ADDITIONAL_DEPENDENCIES 2>&1 | tee -a "$WORKSPACE_DIR/installlog.txt"
+unset JUPYTER_ADDITIONAL_DEPENDENCIES
+
 test -f "$WORKSPACE_DIR/requirements.txt" || cp /etc/skel/requirements_template.txt "$WORKSPACE_DIR/requirements.txt"
-pip install -U -r "$WORKSPACE_DIR/requirements.txt" -r /etc/skel/requirements_template.txt 2>&1 | tee "$WORKSPACE_DIR/installlog.txt"
+pip install -U -r "$WORKSPACE_DIR/requirements.txt" -r /etc/skel/requirements_template.txt 2>&1 | tee -a "$WORKSPACE_DIR/installlog.txt"
 
 test -d "$WORKSPACE_DIR/shared" || ln -s /shared "$WORKSPACE_DIR/shared"
 


### PR DESCRIPTION
Specify a environment variable `JUPYTER_ADDITIONAL_DEPENDENCIES` with a comma-separated list of pip dependencies (trusted values only!).

Additionally, weasyprint is installed per default. We believe that it's useful to generate model derived PDFs.

Resolves https://github.com/DSD-DBS/capella-dockerimages/issues/250