### PR TITLE
feat: Expose idletime of Jupyter container via metrics endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,9 +282,10 @@ run-capella/base: capella/base
 run-jupyter-notebook: jupyter-notebook
 	docker run $(DOCKER_RUN_FLAGS) \
 		-p $(WEB_PORT):8888 \
+		-p $(METRICS_PORT):9118 \
 		-v $$(pwd)/volumes/workspace/notebooks:/tmp/notebooks \
 		-e WORKSPACE_DIR=/tmp/notebooks \
-		-e JUPYTER_BASE_URL=/ \
+		-e JUPYTER_BASE_URL=/subpath \
 		$(DOCKER_PREFIX)$<:$(JUPYTER_NOTEBOOK_REVISION)
 
 run-capella/remote: capella/remote

--- a/docs/docs/jupyter/index.md
+++ b/docs/docs/jupyter/index.md
@@ -29,7 +29,6 @@ The following environment variables can be defined:
 - `WORKSPACE_DIR`: The working directory for JupyterLab.
 - `JUPYTER_BASE_URL`: A context path to access the jupyter server. This allows
   you to run multiple server containers on the same domain.
-- `JUPYTER_TOKEN`: A token for accessing the environment.
 - `JUPYTER_ADDITIONAL_DEPENDENCIES`: A space-separated list of additional pip
   dependencies to install. The variable is passed to the `pip install -U`
   command and may include additional flags. The value is not escaped, only use

--- a/jupyter-notebook/Dockerfile
+++ b/jupyter-notebook/Dockerfile
@@ -31,9 +31,14 @@ ENV PATH="${NVM_DIR}/bin:${PATH}"
 COPY docker-entrypoint.sh /
 COPY requirements_template.txt /etc/skel
 RUN chmod +x /docker-entrypoint.sh && \
-    mkdir -p "/shared" && chown techuser "/shared"
+    mkdir -p "/shared" && chown techuser "/shared" && \
+    chown techuser -R /var/log
 
 USER techuser
+
+RUN pip install --no-cache-dir supervisor requests prometheus_client
+COPY supervisord.conf /etc/supervisord.conf
+COPY jupyter_metrics.py /opt/metrics.py
 
 # Activate virtual environment
 RUN python -m venv /home/techuser/.venv

--- a/jupyter-notebook/docker-entrypoint.sh
+++ b/jupyter-notebook/docker-entrypoint.sh
@@ -26,10 +26,4 @@ pip install -U -r "$WORKSPACE_DIR/requirements.txt" -r /etc/skel/requirements_te
 test -d "$WORKSPACE_DIR/shared" || ln -s /shared "$WORKSPACE_DIR/shared"
 
 echo "---START_SESSION---"
-
-exec jupyter-lab --ip=0.0.0.0 \
-    --port=$JUPYTER_PORT \
-    --no-browser \
-    --ServerApp.authenticate_prometheus=False \
-    --ServerApp.base_url="$JUPYTER_BASE_URL" \
-    --ServerApp.root_dir="$WORKSPACE_DIR"
+exec /opt/.venv/bin/supervisord

--- a/jupyter-notebook/jupyter_metrics.py
+++ b/jupyter-notebook/jupyter_metrics.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import datetime
+import logging
+import os
+from wsgiref import simple_server
+
+import prometheus_client
+import requests
+
+METRICS_PORT = int(os.getenv("METRICS_PORT", "9118"))
+LOGGER = logging.getLogger(__file__)
+
+IDLETIME = prometheus_client.Gauge(
+    "idletime_minutes", "Idletime of the Jupyter server in minutes."
+)
+
+PORT = os.getenv("JUPYTER_PORT", "8888")
+BASE_URL = os.getenv("JUPYTER_BASE_URL", "/")
+if BASE_URL.endswith("/"):
+    BASE_URL = BASE_URL[:-1]
+
+
+def get_last_activity() -> datetime.datetime | None:
+    """Return the last activity from the JupyterLab status API."""
+
+    response = requests.get(
+        f"http://localhost:{PORT}{BASE_URL}/api/status", timeout=1
+    )
+
+    if response.status_code != 200:
+        LOGGER.error(
+            "Failed to get last activity: %s", response.content.decode()
+        )
+        return None
+
+    return datetime.datetime.fromisoformat(response.json()["last_activity"])
+
+
+def get_idletime() -> float:
+    """Return idle time in minutes."""
+
+    now = datetime.datetime.now(datetime.UTC)
+    last_activity = get_last_activity()
+
+    if last_activity is None:
+        return -1
+
+    idletime = (now - last_activity).seconds / 60
+    return round(idletime, 2)
+
+
+IDLETIME.set_function(get_idletime)
+
+
+def start_server(
+    addr: str,
+    port: int,
+    registry: prometheus_client.registry.CollectorRegistry,
+) -> None:
+    """Start a WSGI server for Prometheus metrics."""
+    app = prometheus_client.make_wsgi_app(registry)
+    httpd = simple_server.make_server(addr, port, app)
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    start_server(
+        addr="", port=METRICS_PORT, registry=prometheus_client.REGISTRY
+    )

--- a/jupyter-notebook/supervisord.conf
+++ b/jupyter-notebook/supervisord.conf
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+[program:idletime]
+command=/opt/.venv/bin/python /opt/metrics.py
+user=techuser
+autorestart=true
+
+[program:jupyter]
+command=jupyter-lab --ip=0.0.0.0
+    --port=%(ENV_JUPYTER_PORT)s
+    --no-browser
+    --ServerApp.base_url="%(ENV_JUPYTER_BASE_URL)s"
+    --ServerApp.root_dir="%(ENV_WORKSPACE_DIR)s"
+    --LabApp.token=''
+user=techuser
+autorestart=true
+
+[supervisord]
+nodaemon=true
+childlogdir=/var/log


### PR DESCRIPTION
Add a new endpoint on port 9118, which exposes the idletime of the JupyterLab container.