### PR TITLE
fix: Disable pure::variants build for Capella 7.0.0

### DIFF
--- a/ci-templates/gitlab/image-builder.yml
+++ b/ci-templates/gitlab/image-builder.yml
@@ -331,6 +331,8 @@ t4c/client/remote/pure-variants:
     - job: t4c/client/remote
       optional: true
   rules:
+    - if: '$CAPELLA_VERSION == "7.0.0"'
+      when: never
     - if: '$T4C_CLIENT_REMOTE_PURE_VARIANTS == "1"'
       when: always
   variables:


### PR DESCRIPTION
It doesn't seem to be compatible as of now.