### PR TITLE
fix: Consider changed success message for importer / exporter

### DIFF
--- a/t4c/t4c_cli/backup.py
+++ b/t4c/t4c_cli/backup.py
@@ -74,9 +74,9 @@ def _build_backup_command(
 
 
 def _validate_backup_stdout(line: str) -> None:
-    if re.search(r"[1-9][0-9]* projects imports failed", line):
+    if re.search(r"[1-9][0-9]* projects? imports? failed", line):
         raise RuntimeError("Backup failed. Please check the logs above.")
-    if re.search(r"[1-9][0-9]* archivings failed", line):
+    if re.search(r"[1-9][0-9]* archivings? failed", line):
         raise RuntimeError(
             f"Failed to create archives in output folder ({config.config.t4c.project_dir_path})"
         )
@@ -99,13 +99,13 @@ def run_importer_script(
                 "'!MESSAGE [1-9][0-9]* Succeeded' not found in logs"
             )
     else:
-        if not re.search(r"[1-9][0-9]* projects imports succeeded", stdout):
+        if not re.search(r"[1-9][0-9]* projects? imports? succeeded", stdout):
             raise RuntimeError(
-                "'[1-9][0-9]* projects imports succeeded' not found in logs"
+                "'[1-9][0-9]* projects? imports? succeeded' not found in logs"
             )
-        if not re.search(r"[1-9][0-9]* archivings succeeded", stdout):
+        if not re.search(r"[1-9][0-9]* archivings? succeeded", stdout):
             raise RuntimeError(
-                "'[1-9][0-9]* archivings succeeded' not found in logs"
+                "'[1-9][0-9]* archivings? succeeded' not found in logs"
             )
 
     log.info("Import of model from TeamForCapella server finished")

--- a/t4c/t4c_cli/export.py
+++ b/t4c/t4c_cli/export.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 import os
 import pathlib
+import re
 import shutil
 
 import click
@@ -52,7 +53,7 @@ def _validate_exporter_stdout(line: str) -> None:
         raise RuntimeError("Unknown host")
     elif "No such user:" in line:
         raise RuntimeError("Unknown user")
-    elif "1 projects exports failed" in line:
+    elif re.search(r"[1-9][0-9]* projects? exports? failed", line):
         raise RuntimeError("Export failed")
 
 


### PR DESCRIPTION
The '1 projects imports succeeded' message was changed to '1 project import succeeded' in TeamForCapella 7.0.0