### PR TITLE
fix: Don't install recommended packages in base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -12,17 +12,18 @@ ENV SHELL=/bin/bash
 
 RUN apt-get update && \
     apt-get upgrade --yes && \
-    apt-get install --yes \
+    apt-get install --yes --no-install-recommends \
     gettext-base \
+    git-lfs \
+    gnupg \
     locales \
+    neovim \
     python3 \
     python3-pip \
     python3-venv \
-    git-lfs \
     unzip \
-    neovim \
-    zip \
-    wget && \
+    wget \
+    zip && \
     rm -rf /var/lib/apt/lists/*
 
 RUN echo "en_GB.UTF-8 UTF-8" >> /etc/locale.gen && \

--- a/jupyter-notebook/Dockerfile
+++ b/jupyter-notebook/Dockerfile
@@ -11,8 +11,6 @@ ENV SHELL=/bin/bash
 
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends \
-    git \
-    git-lfs \
     libgirepository1.0-dev \
     libcairo2-dev \
     gir1.2-pango-1.0 \

--- a/t4c/Dockerfile
+++ b/t4c/Dockerfile
@@ -15,7 +15,7 @@ ENV SHELL=/bin/bash
 USER root
 
 RUN apt-get update && \
-    apt-get install -y git-lfs xvfb xauth && \
+    apt-get install -y xvfb xauth && \
     rm -rf /var/lib/apt/lists/*
 
 COPY docker_entrypoint.sh /docker_entrypoint.sh


### PR DESCRIPTION
Get rid of pynvim, which is flagged as malicious in XRAY.

Resolves #313.