### PR TITLE
feat: Install `ssh` client in base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && \
     gnupg \
     locales \
     neovim \
+    openssh-client \
     python3 \
     python3-pip \
     python3-venv \


### PR DESCRIPTION
At least one user uses `ssh-agent` forwarding to access ssh keys in the container. An SSH client might be helful for other use-cases like cloning via SSH in general.

I raised the topic in the team and there were no bojections to add the 20MB large installation of `openssh-client` to the image.