### PR TITLE
ci: Update pre-commit hooks

### DIFF
--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: '3.11'
       - name: Install pre-commit
         run: |-
-          python -m pip install pre-commit
+          python -m pip install 'pre-commit<4.0.0'
       - name: Run pre-commit
         run: |-
           pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: CC0-1.0
 
 default_install_hook_types: [commit-msg, pre-commit]
-default_stages: [commit, merge-commit]
+default_stages: [pre-commit, pre-merge-commit]
 minimum_pre_commit_version: 3.2.0
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -28,7 +28,7 @@ repos:
       - id: fix-byte-order-marker
       - id: trailing-whitespace
   - repo: https://github.com/pylint-dev/pylint
-    rev: v3.1.0
+    rev: v3.3.1
     hooks:
       - id: pylint
         additional_dependencies:
@@ -40,7 +40,7 @@ repos:
           - -dfixme
           - -dduplicate-code
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.3.0
+    rev: 24.8.0
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/isort
@@ -61,7 +61,7 @@ repos:
         additional_dependencies:
           - pydocstyle[toml]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.9.0
+    rev: v1.11.2
     hooks:
       - id: mypy
         additional_dependencies:
@@ -121,18 +121,18 @@ repos:
           - --comment-style
           - '..|  |'
   - repo: https://github.com/fsfe/reuse-tool
-    rev: v3.0.2
+    rev: v4.0.3
     hooks:
       - id: reuse
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.14.0
+    rev: v9.18.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies:
           - '@commitlint/config-conventional'
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.2
+    rev: v3.17.0
     hooks:
       - id: pyupgrade
         args: ['--py311-plus']

--- a/capella/download_archive.py
+++ b/capella/download_archive.py
@@ -21,14 +21,14 @@ CAPELLA_DOWNLOAD_URL = "https://www.eclipse.org/downloads/download.php?file=/cap
 
 
 def get_directory_structure(url: str) -> list[str]:
-    response = requests.get(url)
+    response = requests.get(url, timeout=10)
     response.raise_for_status()
 
     tree = etree.fromstring(response.content, parser=html.HTMLParser())
     return tree.xpath("//*/a/text()")
 
 
-if __name__ == "__main__":
+def main() -> None:
     capella_version = sys.argv[1]
     print(f"Installing Capella {capella_version}")
 
@@ -55,8 +55,10 @@ if __name__ == "__main__":
         f"{capella_archive_path}{archive_name}"
     )
 
-    download_response = requests.get(download_url)
+    download_response = requests.get(download_url, timeout=120)
     download_response.raise_for_status()
-    download_path = pathlib.Path("/opt/capella.tar.gz").write_bytes(
-        download_response.content
-    )
+    pathlib.Path("/opt/capella.tar.gz").write_bytes(download_response.content)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ disable = [
   "too-few-public-methods",
   "too-many-ancestors",
   "too-many-arguments",
+  "too-many-positional-arguments",
   "too-many-boolean-expressions",
   "too-many-branches",
   "too-many-instance-attributes",


### PR DESCRIPTION
Update pre-commit hooks to the latest versions and limit the pre-commit version to <4.0.0 because of
<https://github.com/PyCQA/docformatter/issues/289>.