### PR TITLE
ci: Allow setting the Capella download URL

### DIFF
--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -63,6 +63,7 @@ jobs:
         # prettier-ignore
         run: >
           make ${{ env.images }}
+          CAPELLA_DOWNLOAD_URL="https://mirror.umd.edu/eclipse/capella/core/products/releases/{}"
           CAPELLA_VERSIONS="${{ matrix.capella_version }}"
           DOCKER_PREFIX="${{ env.registry }}"
           CAPELLA_DOCKERIMAGES_REVISION="${{ steps.tag.outputs.branch }}"

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@
 # Add prefix to all dockerimage names, e.g. capella-collab
 export DOCKER_PREFIX ?=
 
+# URL used by to download Capella from
+CAPELLA_DOWNLOAD_URL ?=
+
 # T4C license secret (usually a long numeric string)
 T4C_LICENCE_SECRET ?= XXX
 
@@ -193,6 +196,7 @@ capella/base: base
 		--build-arg BUILD_ARCHITECTURE=$(BUILD_ARCHITECTURE) \
 		--build-arg BASE_IMAGE=$(DOCKER_PREFIX)$<:$(CAPELLA_DOCKERIMAGES_REVISION) \
 		--build-arg BUILD_TYPE=$(CAPELLA_BUILD_TYPE) \
+		--build-arg CAPELLA_DOWNLOAD_URL=$(CAPELLA_DOWNLOAD_URL) \
 		--build-arg CAPELLA_VERSION=$$CAPELLA_VERSION \
 		--build-arg "CAPELLA_DROPINS=$(CAPELLA_DROPINS)" \
 		--build-arg "INJECT_PACKAGES=$(INJECT_LIBS_CAPELLA)" \

--- a/capella/Dockerfile
+++ b/capella/Dockerfile
@@ -61,6 +61,7 @@ FROM base_new as build_online
 # https://github.com/moby/moby/issues/26533#issuecomment-246966836
 ONBUILD ARG CAPELLA_VERSION="5.2.0"
 ONBUILD ARG BUILD_ARCHITECTURE="amd64"
+ONBUILD ARG CAPELLA_DOWNLOAD_URL
 ONBUILD COPY ./download_archive.py /opt/.download_archive.py
 ONBUILD RUN pip install --no-cache-dir requests && \
     python .download_archive.py ${CAPELLA_VERSION};

--- a/capella/download_archive.py
+++ b/capella/download_archive.py
@@ -7,6 +7,7 @@ eclipse download page:
 
 https://download.eclipse.org/capella/core/products/stable/.
 """
+
 import os
 import pathlib
 import sys
@@ -17,7 +18,7 @@ from lxml import etree, html
 CAPELLA_INDEX_URL = (
     "https://mirror.dkm.cz/eclipse/capella/core/products/releases/"
 )
-CAPELLA_DOWNLOAD_URL = "https://www.eclipse.org/downloads/download.php?file=/capella/core/products/releases/{}&r=1"
+CAPELLA_DEFAULT_DOWNLOAD_URL = "https://www.eclipse.org/downloads/download.php?file=/capella/core/products/releases/{}&r=1"
 
 
 def get_directory_structure(url: str) -> list[str]:
@@ -51,9 +52,10 @@ def main() -> None:
         for arch in dir_content
         if arch.endswith("linux-gtk-x86_64.tar.gz")
     )
-    download_url = CAPELLA_DOWNLOAD_URL.format(
-        f"{capella_archive_path}{archive_name}"
-    )
+    download_url = os.getenv(
+        "CAPELLA_DOWNLOAD_URL", CAPELLA_DEFAULT_DOWNLOAD_URL
+    ).format(f"{capella_archive_path}{archive_name}")
+    print(f"Downloading Capella from `{download_url}`...")
 
     download_response = requests.get(download_url, timeout=120)
     download_response.raise_for_status()

--- a/docs/docs/capella/base.md
+++ b/docs/docs/capella/base.md
@@ -110,16 +110,6 @@ If you want to install dropins manually, you can place the dropins in the
 copied into the `dropins` directory of the Capella client without any further
 processing.
 
-#### Optional: Customisation of the Capella client
-
-If you want to customize the Capella client even further, you can:
-
-1. extract the downloaded archive,
-1. apply any modifications (e.g., installation of plugins and/ or dropins) to
-   it, and
-1. compress the modified folder `capella` to get a `capella.zip` or
-   `capella.tar.gz` again.
-
 #### Optional: Workaround of pinned library versions to remove incompatibilities
 
 **Note:** _This workaround is normally handled in the Dockerfile and it is only
@@ -147,19 +137,43 @@ For more information refer to
 
 ### Build it manually with Docker
 
+#### Automatic download of Capella
+
 If you want to download the Capella archive automatically, use the following
-command. Does only work for
+command. It does only work for
 [supported Capella versions](introduction.md#supported-versions).
 
 ```zsh
 docker build -t capella/base capella --build-arg BUILD_TYPE=online --build-arg CAPELLA_VERSION=$CAPELLA_VERSION
 ```
 
+You can further customize the mirror to download the Capella archive from. If
+you don't want to use the default mirror, choose another mirror from
+[this list](https://www.eclipse.org/downloads/download.php?file=/capella/core/products/releases&format=xml).
+
+Then, append `/{}` to the mirror URL and pass it as a build argument to the
+above command, e.g.:
+
+```zsh
+--build-arg CAPELLA_DOWNLOAD_URL="https://mirror.umd.edu/eclipse/capella/core/products/releases/{}"`
+```
+
+#### Build with pre-downloaded version of Capella
+
 If you've downloaded the Capella archive manually before, use this command:
 
 ```zsh
 docker build -t capella/base capella --build-arg CAPELLA_VERSION=$CAPELLA_VERSION
 ```
+
+With this method, you can customize the Capella client before running the above
+command:
+
+1. Extract the downloaded archive,
+1. Apply any modifications (e.g., installation of plugins and/ or dropins) to
+   it, and
+1. Compress the modified folder `capella` to get a `capella.zip` or
+   `capella.tar.gz` again.
 
 ### Miscellaneous
 


### PR DESCRIPTION
Background:

The server endpoint behind the Capella download URL that has been used so far seems to blacklist GitHub actions IP addresses. This commit allows setting the Capella download URL via an environment variable to use a different mirror to download Capella.