### PR TITLE
Use Xpra in desktop mode

### DIFF
--- a/capella/autostart
+++ b/capella/autostart
@@ -8,7 +8,9 @@ export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 # Load environment variables from /etc/environment
 source /etc/environment
 
-nitrogen --restore &
+if command -v nitrogen > /dev/null; then
+  nitrogen --restore &
+fi
 
 if [ "$AUTOSTART_CAPELLA" = "1" ];
 then

--- a/capella/setup/provisioning.py
+++ b/capella/setup/provisioning.py
@@ -165,9 +165,8 @@ def provide_project_dirs_to_capella_plugin(
     projects: list[_ProjectDict],
 ) -> None:
     locations = ":".join([str(project["location"]) for project in projects])
-    pathlib.Path("/etc/environment").write_text(
-        f"export MODEL_INBOX_DIRECTORIES={locations}\n", encoding="utf-8"
-    )
+    with open("/etc/environment", "a", encoding="utf-8") as f:
+        f.write(f"export MODEL_INBOX_DIRECTORIES={locations}\n")
     log.info(
         "Set environment variable MODEL_INBOX_DIRECTORIES to '%s'", locations
     )

--- a/remote/Dockerfile
+++ b/remote/Dockerfile
@@ -27,7 +27,8 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     obconf \
     gettext-base \
     xprintidle \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* && \
+    sed -i -e "/^border\.width:/ s/: .*/: 3/" /usr/share/themes/Clearlooks/openbox-3/themerc
 
 ARG XPRA_REGISTRY=https://xpra.org
 

--- a/remote/Dockerfile
+++ b/remote/Dockerfile
@@ -49,7 +49,6 @@ RUN wget -qO /usr/share/keyrings/xpra.asc ${XPRA_REGISTRY}/xpra.asc && \
 COPY openbox-launcher.sh /usr/local/bin/openbox-launcher.sh
 COPY rc.xml /etc/xdg/openbox/rc.xml
 COPY menu.xml /etc/xdg/openbox/menu.xml
-RUN echo 'export GTK_IM_MODULE=ibus' >> /etc/environment
 
 # Copy Supervisor Configuration
 RUN pip install --no-cache-dir supervisor==4.2.5

--- a/remote/Dockerfile
+++ b/remote/Dockerfile
@@ -45,8 +45,10 @@ RUN wget -qO /usr/share/keyrings/xpra.asc ${XPRA_REGISTRY}/xpra.asc && \
         nginx && \
     rm -rf /var/lib/apt/lists/*
 
+COPY openbox-launcher.sh /usr/local/bin/openbox-launcher.sh
 COPY rc.xml /etc/xdg/openbox/rc.xml
 COPY menu.xml /etc/xdg/openbox/menu.xml
+RUN echo 'export GTK_IM_MODULE=ibus' >> /etc/environment
 
 # Setup Nitrogen (Desktop background)
 COPY wallpaper.png /tmp/wallpaper.png
@@ -73,7 +75,7 @@ RUN mkdir -p /run/xrdp/sockdir && \
     chown techuser /var/log && \
     chown techuser /etc/supervisord.conf /var/log/nginx /var/log/nginx/* && \
     chown techuser /etc/nginx && \
-    touch /etc/environment && chown techuser /etc/environment
+    chown techuser /etc/environment
 
 WORKDIR /home/techuser
 

--- a/remote/Dockerfile
+++ b/remote/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     gettext-base \
     xprintidle \
     && rm -rf /var/lib/apt/lists/* && \
-    sed -i -e "/^border\.width:/ s/: .*/: 3/" /usr/share/themes/Clearlooks/openbox-3/themerc
+    printf '%s\n' >> /usr/share/themes/Natura/openbox-3/themerc "border.width: 3" "window.handle.width: 0"
 
 ARG XPRA_REGISTRY=https://xpra.org
 

--- a/remote/Dockerfile
+++ b/remote/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     obconf \
     gettext-base \
     xprintidle \
-    nitrogen && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 ARG XPRA_REGISTRY=https://xpra.org
 
@@ -49,10 +49,6 @@ COPY openbox-launcher.sh /usr/local/bin/openbox-launcher.sh
 COPY rc.xml /etc/xdg/openbox/rc.xml
 COPY menu.xml /etc/xdg/openbox/menu.xml
 RUN echo 'export GTK_IM_MODULE=ibus' >> /etc/environment
-
-# Setup Nitrogen (Desktop background)
-COPY wallpaper.png /tmp/wallpaper.png
-COPY bg-saved.cfg /home/techuser/.config/nitrogen/bg-saved.cfg
 
 # Copy Supervisor Configuration
 RUN pip install --no-cache-dir supervisor==4.2.5

--- a/remote/bg-saved.cfg
+++ b/remote/bg-saved.cfg
@@ -1,7 +1,0 @@
-# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
-# SPDX-License-Identifier: Apache-2.0
-
-[xin_-1]
-file=/tmp/wallpaper.png
-mode=4
-bgcolor=#000000

--- a/remote/openbox-launcher.sh
+++ b/remote/openbox-launcher.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+xrdb -merge <<\EOF
+Xft.dpi: 96
+EOF
+
+exec openbox-session

--- a/remote/rc.xml
+++ b/remote/rc.xml
@@ -750,6 +750,9 @@
 
   # end of the example
 -->
+  <application type="splash">
+    <position force="yes"><x>50</x><y>50</y></position>
+  </application>
   <application type="normal" title="workspace *- Capella*">
     <fullscreen>yes</fullscreen>
   </application>

--- a/remote/rc.xml
+++ b/remote/rc.xml
@@ -750,7 +750,7 @@
 
   # end of the example
 -->
-  <application name="Capella">
+  <application type="normal" title="workspace *- Capella*">
     <fullscreen>yes</fullscreen>
   </application>
 </applications>

--- a/remote/rc.xml
+++ b/remote/rc.xml
@@ -51,7 +51,7 @@
 </placement>
 
 <theme>
-  <name>Clearlooks</name>
+  <name>Natura</name>
   <titleLayout>NLMC</titleLayout>
   <!--
       available characters are NDSLIMC, each can occur at most once.

--- a/remote/rc.xml
+++ b/remote/rc.xml
@@ -52,7 +52,7 @@
 
 <theme>
   <name>Clearlooks</name>
-  <titleLayout>NLC</titleLayout>
+  <titleLayout>NLMC</titleLayout>
   <!--
       available characters are NDSLIMC, each can occur at most once.
       N: window icon

--- a/remote/supervisord.xpra.conf
+++ b/remote/supervisord.xpra.conf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [program:xpra]
-command=xpra start-desktop :10 --start=/usr/local/bin/openbox-launcher.sh --attach=yes --daemon=no --bind-tcp=0.0.0.0:10001 --min-quality=70
+command=xpra start-desktop :10 --start=/usr/local/bin/openbox-launcher.sh --attach=yes --daemon=no --bind-tcp=0.0.0.0:10001 --min-quality=70 --input-method=keep
 user=techuser
 autorestart=true
 environment=DISPLAY=":10",XPRA_DEFAULT_CONTENT_TYPE="text",XPRA_DEFAULT_VFB_RESOLUTION="1920x1080"

--- a/remote/supervisord.xpra.conf
+++ b/remote/supervisord.xpra.conf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [program:xpra]
-command=xpra start :10 --start=/home/techuser/.config/openbox/autostart --start-env=GTK_IM_MODULE=ibus --attach=yes --daemon=no --bind-tcp=0.0.0.0:10001 --min-quality=70
+command=xpra start-desktop :10 --start=/usr/local/bin/openbox-launcher.sh --attach=yes --daemon=no --bind-tcp=0.0.0.0:10001 --min-quality=70
 user=techuser
 autorestart=true
 environment=DISPLAY=":10",XPRA_DEFAULT_CONTENT_TYPE="text",XPRA_DEFAULT_VFB_RESOLUTION="1920x1080"


### PR DESCRIPTION
Compared to using the Xpra HTML5 client in window mode, the desktop mode features much better window management thanks to the battle-proven Openbox WM. The two most noticable improvements are:

1. The Capella main window automatically is fullscreened, removing the unneeded window decorations and making it always follow the browser window size. This also applies to Xrdp based session, which previously had every window in fullscreen mode, including (normally small) dialogs.

2. Modal dialogs (like the "New Project" or "Properties" dialogs) now properly stay on top of the Capella main window. Previously, they could disappear behind the main window. This avoids the awkward situations where a hidden modal dialog prevents interaction with the main window, making it appear completely frozen.

This change currently still has some unfixed issues.

- [x] The Capella splash screen isn't properly displayed during first start. When restarting Capella inside an established session, it does show up though.
- [x] ~~When resizing the browser window too quickly, Capella sometimes gets stuck in a too large or too small size, or disappears entirely. Refreshing the tab fixes this.~~ Acceptable limitation. https://github.com/DSD-DBS/capella-dockerimages/pull/328#issuecomment-2405503178
- [x] When clicking on something, or when the cursor style changes (e.g. from normal cursor to the "resize drag" cursor), the cursor turns very large, and becomes the normal size again once moved.
- [x] There should be a wallpaper, but the nitrogen process which should set it crashes with SIGABRT. => The `wallpaper.png` file in the repo is empty, and I can't find the contents. Removed nitrogen as suggested in https://github.com/DSD-DBS/capella-dockerimages/pull/328#issuecomment-2405503178.

Resolves #317