### PR TITLE
ci: Bump `pre-commit` to latest version

### DIFF
--- a/.github/workflows/deploy-docker-images.yml
+++ b/.github/workflows/deploy-docker-images.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: '3.11'
       - name: Install pre-commit
         run: |-
-          python -m pip install 'pre-commit<4.0.0'
+          python -m pip install 'pre-commit'
       - name: Run pre-commit
         run: |-
           pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
           - -dfixme
           - -dduplicate-code
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/isort
@@ -48,7 +48,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.5
+    rev: eb1df347edd128b30cd3368dddc3aa65edcfac38
     hooks:
       - id: docformatter
         additional_dependencies:


### PR DESCRIPTION
docformatter is not compatible yet in the latest release, therefore pointing to the latest commit hash on the main branch.