### PR TITLE
fix: Fix an issue where modals could be unfocused causing soft-locks

### DIFF
--- a/remote/Dockerfile
+++ b/remote/Dockerfile
@@ -45,6 +45,22 @@ RUN wget -qO /usr/share/keyrings/xpra.asc ${XPRA_REGISTRY}/xpra.asc && \
         nginx && \
     rm -rf /var/lib/apt/lists/*
 
+# Inject script to force focus on modal windows in xpra client
+# and remove the compressed index.html files because they don't contain our fix
+RUN sed -i '/load_default_settings();/a \
+setInterval(() => {\
+for (const [id, win] of Object.entries(client.id_to_window).toReversed()) {\
+    if (win.metadata.modal) {\
+        if (client.topwindow !== parseInt(id)) {\
+            console.log("Forcing focus on modal window", id);\
+            client.set_focus(win);\
+            break;\
+        }\
+    }\
+}\
+}, 100);' /usr/share/xpra/www/index.html \
+&& rm /usr/share/xpra/www/index.html.gz \
+&& rm /usr/share/xpra/www/index.html.br
 COPY rc.xml /etc/xdg/openbox/rc.xml
 COPY menu.xml /etc/xdg/openbox/menu.xml
 


### PR DESCRIPTION
By default, the Xpra web client allows users to unfocus modals. When a modal is triggered, the main window is frozen though, so if the modal is unfocused users are left with a frozen main window. By injecting some javascript, we can force modal windows to always be focused. This should reduce the amount of users that accidentally trigger a modal and then think their connection froze.