### PR TITLE
fix(ci-templates): Model validation unable to update local refs

### DIFF
--- a/ci-templates/gitlab/model-validation.yml
+++ b/ci-templates/gitlab/model-validation.yml
@@ -8,7 +8,7 @@ model-validation:
   script:
     # As our containers run with techuser (non-root) git commands fail with dubious ownership, see <https://gitlab.com/gitlab-org/gitlab-runner/-/issues/29022> for the solution.
     - git config --global --add safe.directory ${CI_PROJECT_DIR}
-    - git fetch
+    - git fetch origin ${$CI_COMMIT_BRANCH}
     - if [ ! -z $CI_COMMIT_BRANCH ]; then git reset --hard origin/$CI_COMMIT_BRANCH; fi
     - BUILD_DIR=$(pwd)
     - if [ ! -f ".project" ]; then echo "The model validator requires a '.project' file!" && exit 1; fi
@@ -29,6 +29,8 @@ model-validation:
     paths:
       - "validation-results.html"
   variables:
+    # Only fetch the last commit for validation
+    GIT_DEPTH: 1
     # Virtual display used to run Capella in the background.
     # Do not modify the value!
     DISPLAY: ":99"


### PR DESCRIPTION
When feature branches exist, the model validation job fails, running on a different branch (CI_COMMIT_BRANCH).

So this commit changes fetching of just the CI_COMMIT_BRANCH and also limits the fetched commit history to only the last commit.