### PR TITLE
feat: Automatically enable Capella UI freeze monitoring

### DIFF
--- a/capella/setup/setup_workspace.py
+++ b/capella/setup/setup_workspace.py
@@ -81,4 +81,11 @@ if __name__ == "__main__":
         "false",
     )
 
+    # Enable UI freeze monitoring
+    _replace_config(
+        ECLIPSE_SETTINGS_BASE_PATH / "org.eclipse.ui.monitoring.prefs",
+        "monitoring_enabled",
+        "true",
+    )
+
     _set_git_merge_mode()


### PR DESCRIPTION
Enable Capella's built-in UI freeze monitoring with default settings. I've been unable to trigger a situation where UI freezes are actually logged, so this needs more testing before being merged.

Closes #318