### PR TITLE
fix: Use internal browser for help instead of broken external one

### DIFF
--- a/capella/setup/setup_workspace.py
+++ b/capella/setup/setup_workspace.py
@@ -74,4 +74,11 @@ if __name__ == "__main__":
         f"{WORKSPACE_DIR}/git",
     )
 
+    # Force Help to built-in browser
+    _replace_config(
+        ECLIPSE_SETTINGS_BASE_PATH / "org.eclipse.help.base.prefs",
+        "always_external_browser",
+        "false",
+    )
+
     _set_git_merge_mode()


### PR DESCRIPTION
Change Capella settings to force help to be shown using the internal browser. There was discussion about exposing help as outside the container as well, but this is probably not worth the effort.

Closes #301
Closes #159
Closes DSD-DBS/capella-collab-manager#753
Closes DSD-DBS/capella-collab-manager#576