### PR TITLE
Disable overlay scrolling in Capella

### DIFF
--- a/capella/autostart
+++ b/capella/autostart
@@ -4,6 +4,7 @@
 
 # Autostart script
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export GTK_OVERLAY_SCROLLING=0
 
 # Load environment variables from /etc/environment
 source /etc/environment


### PR DESCRIPTION
Capella's diagram view doesn't add extra padding around the content. With overlay scrolling enabled, this frequently leads to the scrollbars popping up unintentionally, and the user being unable to properly interact with items on the bottom or right edge of the view.

Disabling the overlay scrolling feature makes the scrollbars always appear and reserve the space they need, thereby eliminating the issue.