### PR TITLE
fix: Explicitly install x11-server-utils

### DIFF
--- a/capella/Dockerfile
+++ b/capella/Dockerfile
@@ -83,6 +83,7 @@ RUN apt-get update && \
     apt-get install -y \
     libxtst6 \
     xdg-utils \
+    x11-xserver-utils \
     xvfb \
     xauth \
     dbus-x11 && \


### PR DESCRIPTION
Previously, it was only installed when the debian base image had recommended installs on. In cases where it wasn't installed, disabling the BEL sound did not work.

Closes #294