### PR TITLE
jupyter: Install less

### DIFF
--- a/jupyter-notebook/Dockerfile
+++ b/jupyter-notebook/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
     libcairo2-dev \
     gir1.2-pango-1.0 \
     curl \
+    less \
     weasyprint \
     graphviz && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
`less` is the default pager used for git commands. Without it, some git commands become almost unusable in the Jupyter terminal. One common example is `git log`, which will dump out the entire commit history onto the terminal, with the new and interesting commits being pushed way off screen (and sometimes out of the scroll buffer entirely).