### PR TITLE
feat: Remove node from jupyter image

### DIFF
--- a/jupyter-notebook/Dockerfile
+++ b/jupyter-notebook/Dockerfile
@@ -20,13 +20,6 @@ RUN apt-get update && \
     graphviz && \
     rm -rf /var/lib/apt/lists/*
 
-ENV NVM_DIR=/usr/local/nvm
-RUN mkdir ${NVM_DIR} && \
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
-    bash -c "source ${NVM_DIR}/nvm.sh && nvm install --lts" && \
-    ln -s ${NVM_DIR}/versions/node/*/bin ${NVM_DIR}/bin
-ENV PATH="${NVM_DIR}/bin:${PATH}"
-
 COPY docker-entrypoint.sh /
 COPY requirements_template.txt /etc/skel
 RUN chmod +x /docker-entrypoint.sh && \


### PR DESCRIPTION
capellambse-context-diagrams no longer needs node to work, so we can remove it.

Closes #374