### PR TITLE
feat: Map TeamForCapella commits 1:1 to Git commits

### DIFF
--- a/cli/cdi/jupyter/build.py
+++ b/cli/cdi/jupyter/build.py
@@ -34,6 +34,7 @@ def jupyter(
     base_image_tag = base_image_tag.format(
         cdi_revision=git.get_current_cdi_revision()
     )
+    image_tag = image_tag.format(cdi_revision=git.get_current_cdi_revision())
 
     if not skip_base_image:
         base_build.command(

--- a/cli/cdi/jupyter/run.py
+++ b/cli/cdi/jupyter/run.py
@@ -6,7 +6,7 @@ import pathlib
 
 import typer
 
-from cdi import args, docker, helpers
+from cdi import args, docker, git, helpers
 from cdi import logging as _logging
 from cdi.base import args as base_args
 from cdi.jupyter import build as jupyter_builder
@@ -40,6 +40,7 @@ def jupyter(
     _verbose: _logging.VerboseOption = False,
 ) -> None:
     helpers.print_cli_options(locals(), "running Jupyter")
+    image_tag = image_tag.format(cdi_revision=git.get_current_cdi_revision())
 
     if not skip_build:
         jupyter_builder.jupyter(

--- a/cli/cdi/syncer/args.py
+++ b/cli/cdi/syncer/args.py
@@ -156,3 +156,24 @@ LocalFileHandlerPathOption = t.Annotated[
         dir_okay=True,
     ),
 ]
+
+
+class CommitMapping(str, enum.Enum):
+    EXACT = "exact"
+    GROUPED = "grouped"
+
+
+CommitMappingOption = t.Annotated[
+    CommitMapping,
+    typer.Option(
+        "--commit-mapping",
+        help=(
+            "Specify the commit mapping of T4C to Git commits."
+            " With the 'exact' option, every TeamForCapella commit is mapped to an individual Git commit."
+            " The 'exact' option is limited to 20 commits. If there are more than 20 T4C commits since the last run,"
+            " it falls back to the 'grouped' option. The 'grouped' option creates one Git commit with all T4C changes since"
+            " the last commit."
+        ),
+        rich_help_panel="Importer Options",
+    ),
+]

--- a/cli/cdi/syncer/run.py
+++ b/cli/cdi/syncer/run.py
@@ -218,6 +218,7 @@ def t4c2git(
     t4c_server_port: syncer_args.T4CServerPortOption = 2036,
     t4c_username: syncer_args.T4CUsername = "admin",
     t4c_password: syncer_args.T4CPassword = None,
+    commit_mapping: syncer_args.CommitMappingOption = syncer_args.CommitMapping.EXACT,
     _verbose: _logging.VerboseOption = False,
 ) -> None:
     helpers.print_cli_options(locals(), "running T4C Importer")
@@ -319,6 +320,8 @@ def t4c2git(
     environment["T4C_PROJECT_NAME"] = t4c_project_name
     environment["T4C_USERNAME"] = t4c_username
     environment["T4C_PASSWORD"] = t4c_password
+
+    environment["CDI_COMMIT_MAPPING"] = commit_mapping.value
 
     if debug:
         volumes[pathlib.Path("./t4c/t4c_cli")] = pathlib.PurePosixPath(

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -50,10 +50,6 @@ exclude_also = [
 ]
 skip_covered = true
 
-[tool.docformatter]
-wrap-descriptions = 72
-wrap-summaries = 79
-
 [tool.mypy]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/t4c/t4c_cli/util/capella.py
+++ b/t4c/t4c_cli/util/capella.py
@@ -29,7 +29,7 @@ DEFAULT_CAPELLA_COMMAND = [
 def run_capella_command_and_handle_errors(
     application: str,
     arguments: list[str],
-    stdout_line_validator: t.Callable[[str], None],
+    stdout_line_validator: t.Callable[[str], None] | None = None,
 ) -> tuple[str, str]:
     """Run the provided Capella command.
 
@@ -86,7 +86,8 @@ def run_capella_command_and_handle_errors(
                 )
                 sys.exit(1)
 
-            stdout_line_validator(line)
+            if stdout_line_validator:
+                stdout_line_validator(line)
 
         if popen.stderr:
             stderr = popen.stderr.read()
@@ -98,6 +99,10 @@ def run_capella_command_and_handle_errors(
         )
 
     return stdout, stderr
+
+
+def is_capella_7_x_x() -> bool:
+    return bool(re.match(r"7.[0-9]+.[0-9]+", config.config.capella.version))
 
 
 def is_capella_5_x_x() -> bool:

--- a/t4c/t4c_cli/util/config.py
+++ b/t4c/t4c_cli/util/config.py
@@ -17,7 +17,7 @@ class GitConfig:
     entrypoint: str | None = os.getenv("ENTRYPOINT") or os.getenv(
         "GIT_REPO_ENTRYPOINT"
     )
-    email: str = os.getenv("GIT_EMAIL", "backup@example.com")
+    email: str = os.getenv("GIT_EMAIL", "")
     username: str = os.getenv("GIT_USERNAME", "")
     password: str = os.getenv("GIT_PASSWORD", "")
     askpass: str = "/etc/git_askpass.py"
@@ -30,9 +30,6 @@ class T4CConfig:
     repo_port: str = os.getenv("T4C_REPO_PORT", "2036")
     repo_name: str = os.environ["T4C_REPO_NAME"]
     credentials_file_path: str = "/tmp/t4c_credentials"
-    include_commit_history = str_to_bool(
-        os.getenv("INCLUDE_COMMIT_HISTORY", "false")
-    )
 
     def __init__(self) -> None:
         with open(self.credentials_file_path, "w", encoding="utf-8") as file:
@@ -50,9 +47,15 @@ class FileHandler(enum.Enum):
     LOCAL = "LOCAL"
 
 
+class CommitMapping(str, enum.Enum):
+    EXACT = "exact"
+    GROUPED = "grouped"
+
+
 @dataclasses.dataclass
 class GeneralConfig:
     file_handler = FileHandler(os.getenv("FILE_HANDLER", "GIT").upper())
+    commit_mapping = CommitMapping(os.getenv("CDI_COMMIT_MAPPING", "exact"))
 
     git: GitConfig = dataclasses.field(default_factory=GitConfig)
     t4c: T4CConfig = dataclasses.field(default_factory=T4CConfig)

--- a/t4c/t4c_cli/util/datetime.py
+++ b/t4c/t4c_cli/util/datetime.py
@@ -20,4 +20,6 @@ def format_datetime_to_isoformat_without_tz(
         The formatted datetime string in the format: "YYYY-MM-DDTHH:MM:SS.sss".
         For example, a datetime object representing April 8, 2024, at 15:30:45.124567 would be formatted as "2024-04-08T15:30:45.124".
     """
-    return datetime_arg.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
+    return datetime_arg.astimezone(tz=datetime.UTC).strftime(
+        "%Y-%m-%dT%H:%M:%S.%f"
+    )[:-3]

--- a/t4c/t4c_cli/util/t4c.py
+++ b/t4c/t4c_cli/util/t4c.py
@@ -1,16 +1,10 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import datetime
 import glob
 import logging
 import os
 import pathlib
-
-import yaml
-from lxml import etree
-
-from . import config
 
 logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
 log = logging.getLogger("T4C")
@@ -26,56 +20,6 @@ def check_dir_for_aird_files(resolved_model_dir: pathlib.Path) -> None:
         raise RuntimeError(
             f"{resolved_model_dir.absolute()} contains no .aird file"
         )
-
-
-def extract_t4c_commit_information() -> tuple[str, datetime.datetime | None]:
-    project_dir = pathlib.Path(config.config.t4c.project_dir_path)
-
-    log.info(
-        "Start extracting TeamForCapella commit information in %s", project_dir
-    )
-
-    activity_metadata_file = get_single_file_by_t4c_pattern_or_raise(
-        prefix="CommitHistory_",
-        file_format="activitymetadata",
-        root_dir=project_dir,
-    )
-
-    activitymetadata_tree: etree._ElementTree = etree.parse(
-        project_dir / activity_metadata_file
-    )
-
-    activitymetadata: etree._Element = activitymetadata_tree.getroot()
-
-    if len(activitymetadata) == 0:
-        log.info("no commits since last backup")
-        return "", None
-
-    commit_information: list[dict[str, str | None]] = []
-    last_commit_datetime = datetime.datetime.fromtimestamp(0, tz=datetime.UTC)
-
-    for activity in activitymetadata:
-        activity_dict = _create_activity_dict(activity)
-
-        if not activity_dict:
-            continue
-
-        if commit_date := activity.attrib.get("date", None):
-            commit_datetime = datetime.datetime.fromisoformat(commit_date)
-            if commit_datetime and commit_datetime > last_commit_datetime:
-                last_commit_datetime = commit_datetime
-
-        commit_information.append(activity_dict)
-
-    log.info(
-        "Finished extracting TeamForCapella commit information in %s",
-        activity_metadata_file,
-    )
-
-    return (
-        yaml.dump(commit_information, sort_keys=False),
-        last_commit_datetime,
-    )
 
 
 def get_single_file_by_t4c_pattern_or_raise(
@@ -96,21 +40,3 @@ def get_single_file_by_t4c_pattern_or_raise(
         )
 
     return matching_files[0]
-
-
-def _create_activity_dict(
-    activity: etree._Element,
-) -> dict[str, str | None] | None:
-    attributes = activity.attrib
-
-    if description := attributes.get("description", None):
-        description = description.rstrip()
-
-        if "[Import][Application]" in description:
-            return None
-
-    return {
-        "user": attributes.get("userId", None),
-        "time": attributes.get("date", None),
-        "description": description,
-    }


### PR DESCRIPTION
Until now, TeamForCapella commits were grouped and one Git commit was created per backup.

This commit introduces a new option to create one Git commit per TeamForCapella commit. This is more resource-intensive, but better for projects with high traceability needs.

TODO:

- [x] Handle commits of other projects in the same TeamForCapella repository. These commits may result in errors during export which have to be handled properly.
- [x] Run some additional manual tests.
- [x] Test local file handler.
- [x] Add the commit mapping option to the CLI.

Resolves #309