### PR TITLE
feat!: Remove support for old GTK versions

### DIFF
--- a/capella/Dockerfile
+++ b/capella/Dockerfile
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 ARG BASE_IMAGE=base
 ARG BUILD_TYPE=online
-ARG INSTALL_OLD_GTK_VERSION=true
 FROM ${BASE_IMAGE} AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -11,48 +10,29 @@ ENV DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 ENV SHELL=/bin/bash
 
-FROM base AS old_gtk_true
-
-ONBUILD USER root
-
-# hadolint ignore=SC2046
-ONBUILD RUN echo "deb http://de.archive.ubuntu.com/ubuntu/ focal main" >> /etc/apt/sources.list.d/focal.list; \
-    ## Import the required keys
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32; \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 871920D1991BC93C; \
-    apt-get update; \
-    ## Install the packages
-    apt-get install -y --no-install-recommends \
-    libjavascriptcoregtk-4.0-18=2.28.1-1 \
-    libwebkit2gtk-4.0-37=2.28.1-1; \
-    rm /etc/apt/sources.list.d/focal.list; \
-    rm -rf /var/lib/apt/lists/*;
-
-FROM base AS old_gtk_false
-
-ONBUILD USER root
-ONBUILD RUN apt-get update && \
+USER root
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     libjavascriptcoregtk-4.0-18 \
     libwebkit2gtk-4.0-37 && \
     rm -rf /var/lib/apt/lists/*;
 
-FROM old_gtk_${INSTALL_OLD_GTK_VERSION} AS base_new
-
 WORKDIR /opt/
+USER techuser
 
-FROM base_new AS build_online
+FROM base AS build_online
+
 # Download a Capella executable archive
-
 # https://github.com/moby/moby/issues/26533#issuecomment-246966836
 ONBUILD ARG CAPELLA_VERSION="5.2.0"
 ONBUILD ARG BUILD_ARCHITECTURE="amd64"
 ONBUILD ARG CAPELLA_DOWNLOAD_URL
+ONBUILD USER root
 ONBUILD COPY ./download_archive.py /opt/.download_archive.py
 ONBUILD RUN pip install --no-cache-dir requests && \
     python .download_archive.py ${CAPELLA_VERSION};
 
-FROM base_new AS build_offline
+FROM base AS build_offline
 
 # ONBUILD is required here
 # https://github.com/moby/moby/issues/26533#issuecomment-246966836
@@ -60,9 +40,9 @@ ONBUILD ARG CAPELLA_VERSION="5.2.0"
 ONBUILD ARG BUILD_ARCHITECTURE="amd"
 ONBUILD COPY ./versions/${CAPELLA_VERSION}/${BUILD_ARCHITECTURE}/capella.* /opt/
 
-
 FROM build_${BUILD_TYPE}
 
+USER root
 ARG CAPELLA_VERSION
 
 RUN apt-get update && \

--- a/cli/cdi/capella/args.py
+++ b/cli/cdi/capella/args.py
@@ -76,16 +76,6 @@ CapellaDropinsOption = t.Annotated[
     ),
 ]
 
-InstallOldGTKVersionOption = t.Annotated[
-    bool,
-    typer.Option(
-        "--old-gtk-version/--current-gtk-version",
-        help="Old GTK versions can improve the Capella description editor in Capella versions < 7.0.0.",
-        envvar="INSTALL_OLD_GTK_VERSION",
-        rich_help_panel=CAPELLA_BUILD_OPTIONS,
-    ),
-]
-
 CAPELLA_RUN_OPTIONS = "Capella Run Options"
 
 DisableSemanticBrowserOption = t.Annotated[

--- a/cli/cdi/capella/build.py
+++ b/cli/cdi/capella/build.py
@@ -161,7 +161,6 @@ def capella(
     build_type: capella_args.BuildTypeOption = capella_args.BuildType.OFFLINE,
     capella_download_url: capella_args.CapellaDownloadURLOption = None,
     capella_dropins: capella_args.CapellaDropinsOption = "",
-    install_old_gtk_version: capella_args.InstallOldGTKVersionOption = False,
     pure_variants_client: pv_args.PureVariantsOption = False,
     pure_variants_version: pv_args.PureVariantsVersionOption = "6.0.1",
     labels: args.ImageLabelOption = None,
@@ -240,9 +239,6 @@ def capella(
                     "CAPELLA_DOWNLOAD_URL": capella_download_url or "",
                     "CAPELLA_VERSION": capella_version,
                     "CAPELLA_DROPINS": capella_dropins,
-                    "INSTALL_OLD_GTK_VERSION": (
-                        "true" if install_old_gtk_version else "false"
-                    ),
                 },
                 labels=helpers.transform_labels(labels),
             )

--- a/cli/cdi/capella/run.py
+++ b/cli/cdi/capella/run.py
@@ -42,7 +42,6 @@ def capella(
     build_type: capella_args.BuildTypeOption = capella_args.BuildType.OFFLINE,
     capella_download_url: capella_args.CapellaDownloadURLOption = None,
     capella_dropins: capella_args.CapellaDropinsOption = "",
-    install_old_gtk_version: capella_args.InstallOldGTKVersionOption = False,
     pure_variants_client: pv_args.PureVariantsOption = False,
     pure_variants_version: pv_args.PureVariantsVersionOption = "6.0.1",
     connect_to_x_server: args.ConnectToXServerOption = False,
@@ -88,7 +87,6 @@ def capella(
             build_type=build_type,
             capella_download_url=capella_download_url,
             capella_dropins=capella_dropins,
-            install_old_gtk_version=install_old_gtk_version,
             pure_variants_client=pure_variants_client,
             pure_variants_version=pure_variants_version,
         )

--- a/cli/cdi/syncer/run.py
+++ b/cli/cdi/syncer/run.py
@@ -134,7 +134,6 @@ def git2t4c(
             build_type=build_type,
             capella_download_url=capella_download_url,
             capella_dropins=capella_dropins,
-            install_old_gtk_version=False,
             pure_variants_client=False,
         )
 
@@ -285,7 +284,6 @@ def t4c2git(
             build_type=build_type,
             capella_download_url=capella_download_url,
             capella_dropins=capella_dropins,
-            install_old_gtk_version=False,
             pure_variants_client=False,
         )
 


### PR DESCRIPTION
In https://github.com/DSD-DBS/capella-dockerimages/pull/392, `INSTALL_OLD_GTK_VERSION` has been changed to a default value of false. Since we want to focus on newer Capella versions going forward, we want to reduce the maintanance burden and therefore remove the option to install old GTK versions.
This will only affect users with Capella 5.X.X and 6.X.X with description editor issues. 