### PR TITLE
fix(t4c2git): Don't copy commit history as file into Git repository

### DIFF
--- a/t4c/t4c_cli/backup.py
+++ b/t4c/t4c_cli/backup.py
@@ -196,15 +196,6 @@ def copy_exported_files_into_git_repo() -> None:
         dirs_exist_ok=True,
     )
 
-    shutil.copy2(
-        next(project_dir.glob("CommitHistory__*.activitymetadata")),
-        target_directory / "CommitHistory.activitymetadata",
-    )
-    shutil.copy2(
-        next(project_dir.glob("CommitHistory__*.json*")),
-        target_directory / "CommitHistory.json",
-    )
-
     log.info("Finished copying files...")
 
 


### PR DESCRIPTION
The T4C commit information is already contained in Git commits. There is no need to have it as file in the repository.