### PR TITLE
perf: Don't register XpraCollector when using other connection method

### DIFF
--- a/cli/cdi/helpers.py
+++ b/cli/cdi/helpers.py
@@ -66,7 +66,7 @@ def configure_remote_connection(
 ) -> None:
     environment["CONNECTION_METHOD"] = connection_method.value
     environment["XPRA_SUBPATH"] = xpra_subpath
-    environment["RDP_PASSWORD"] = rdp_password if rdp_password else ""
+    environment["RMT_PASSWORD"] = rdp_password if rdp_password else ""
 
     if connection_method == args.ConnectionMethod.XRDP:
         ports[rdp_port] = 3389

--- a/remote/metrics.py
+++ b/remote/metrics.py
@@ -261,7 +261,8 @@ class XpraCollector(prometheus_client.registry.Collector):
 IDLETIME.set_function(IdleTimer().get_idletime)
 
 prometheus_client.REGISTRY.register(ProcessCollector())
-prometheus_client.REGISTRY.register(XpraCollector())
+if os.getenv("CONNECTION_METHOD", "").lower() == "xpra":
+    prometheus_client.REGISTRY.register(XpraCollector())
 
 
 def start_server(


### PR DESCRIPTION
If the connection method isn't xpra, the xpra metrics are not relevant.