### PR TITLE
build: Also push intermediate images in CLI

### DIFF
--- a/cli/cdi/capella/build.py
+++ b/cli/cdi/capella/build.py
@@ -256,6 +256,8 @@ def capella(
                 },
                 labels=helpers.transform_labels(labels),
             )
+        if push:
+            docker.push_image(image_name)
 
     if t4c_client:
         image_core = "t4c/client"
@@ -277,6 +279,8 @@ def capella(
                 labels=helpers.transform_labels(labels),
             )
         image_name = t4c_image_name
+        if push:
+            docker.push_image(image_name)
 
     if remote:
         image_core += "/remote"
@@ -292,6 +296,8 @@ def capella(
             labels=helpers.transform_labels(labels),
         )
         image_name = remote_image_name
+        if push:
+            docker.push_image(image_name)
 
     if pure_variants_client:
         pure_variants_image = docker.build_image_name(
@@ -306,9 +312,8 @@ def capella(
             labels=helpers.transform_labels(labels),
         )
         image_name = pure_variants_image
-
-    if push:
-        docker.push_image(image_name)
+        if push:
+            docker.push_image(image_name)
 
     if build_type == capella_args.BuildType.ONLINE:
         log.warning(

--- a/cli/cdi/eclipse/build.py
+++ b/cli/cdi/eclipse/build.py
@@ -153,6 +153,9 @@ def eclipse(
                 labels=helpers.transform_labels(labels),
             )
 
+        if push:
+            docker.push_image(image_name)
+
     if remote:
         image_core += "/remote"
         remote_image_name = docker.build_image_name(
@@ -168,6 +171,9 @@ def eclipse(
         )
         image_name = remote_image_name
 
+        if push:
+            docker.push_image(image_name)
+
     if pure_variants_client:
         pure_variants_image = docker.build_image_name(
             image_prefix, image_core + "/pure-variants", image_tag
@@ -182,8 +188,8 @@ def eclipse(
         )
         image_name = pure_variants_image
 
-    if push:
-        docker.push_image(image_name)
+        if push:
+            docker.push_image(image_name)
 
 
 def get_final_eclipse_image_tag(

--- a/cli/cdi/papyrus/build.py
+++ b/cli/cdi/papyrus/build.py
@@ -123,6 +123,9 @@ def papyrus(
             labels=helpers.transform_labels(labels),
         )
 
+    if push:
+        docker.push_image(image_name)
+
     if remote:
         remote_image_name = docker.build_image_name(
             image_prefix, "papyrus/remote", image_tag
@@ -137,5 +140,5 @@ def papyrus(
         )
         image_name = remote_image_name
 
-    if push:
-        docker.push_image(image_name)
+        if push:
+            docker.push_image(image_name)


### PR DESCRIPTION
This is required for the CCM Makefile to push the `t4c/client/base` image.