### PR TITLE
fix(backup): Default to grouped T4C to Git mapping again

### DIFF
--- a/t4c/t4c_cli/util/config.py
+++ b/t4c/t4c_cli/util/config.py
@@ -55,7 +55,7 @@ class CommitMapping(str, enum.Enum):
 @dataclasses.dataclass
 class GeneralConfig:
     file_handler = FileHandler(os.getenv("FILE_HANDLER", "GIT").upper())
-    commit_mapping = CommitMapping(os.getenv("CDI_COMMIT_MAPPING", "exact"))
+    commit_mapping = CommitMapping(os.getenv("CDI_COMMIT_MAPPING", "grouped"))
 
     git: GitConfig = dataclasses.field(default_factory=GitConfig)
     t4c: T4CConfig = dataclasses.field(default_factory=T4CConfig)


### PR DESCRIPTION
The exact commit mapping is still unreliable due to some external factors. When it's stable again, we'll change the default to EXACT again.

It can still be manually activated via the environment variable CDI_COMMIT_MAPPING.