### PR TITLE
fix: Properly set initial screen resolution

### DIFF
--- a/remote/supervisord.xpra.conf
+++ b/remote/supervisord.xpra.conf
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [program:xpra]
-command=xpra start :10 --start=/home/techuser/.config/openbox/autostart --session-name="%(ENV_DISPLAY_NAME)s" --attach=yes --daemon=no --bind-tcp=0.0.0.0:10001 --min-quality=70 --input-method=keep
+command=xpra start :10 --start=/home/techuser/.config/openbox/autostart --session-name="%(ENV_DISPLAY_NAME)s" --attach=yes --daemon=no --bind-tcp=0.0.0.0:10001 --min-quality=70 --input-method=keep --resize-display="1920x1080"
 user=techuser
 autorestart=true
-environment=DISPLAY=":10",XPRA_DEFAULT_CONTENT_TYPE="text",XPRA_DEFAULT_VFB_RESOLUTION="1920x1080"
+environment=DISPLAY=":10",XPRA_DEFAULT_CONTENT_TYPE="text"
 stdout_logfile=/var/log/session/%(program_name)s.stdout.log
 stderr_logfile=/var/log/session/%(program_name)s.stderr.log
 


### PR DESCRIPTION
This makes the Capella splashscreen visible on smaller devices as well.